### PR TITLE
Added a new option (keyValueListFile) for --node-key-value and --way-key-value tagfilters

### DIFF
--- a/tagfilter/src/main/java/org/openstreetmap/osmosis/tagfilter/common/KeyValueFileReader.java
+++ b/tagfilter/src/main/java/org/openstreetmap/osmosis/tagfilter/common/KeyValueFileReader.java
@@ -11,8 +11,6 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.openstreetmap.osmosis.core.OsmosisRuntimeException;
-
 
 /**
  * Reads the content of a file containing "key.value" tags.
@@ -39,25 +37,17 @@ public class KeyValueFileReader {
 	 */
 	private BufferedReader reader;
 
-	/**
-	 * The filename for error-messages.
-	 */
-	private String fileName;
-
 
 	/**
 	 * Creates a new instance.
 	 * 
 	 * @param keyValueFile
 	 *            The file to read key.value tags from.
+	 * @throws FileNotFoundException
+	 *             in case the specified file does not exist
 	 */
-	public KeyValueFileReader(final File keyValueFile) {
-		try {
-			this.reader = new BufferedReader(new FileReader(keyValueFile));
-			this.fileName = keyValueFile.getName();
-		} catch (FileNotFoundException ex) {
-			throw new OsmosisRuntimeException("Unable to read from key.value file " + fileName + ".", ex);
-		}
+	public KeyValueFileReader(final File keyValueFile) throws FileNotFoundException {
+		this.reader = new BufferedReader(new FileReader(keyValueFile));
 	}
 
 
@@ -65,16 +55,16 @@ public class KeyValueFileReader {
 	 * Reads the file and returns an array of key.value tags
 	 * 
 	 * @return an array of key.value tags
+	 * @throws IOException
+	 *             in case the file could not be read
 	 */
-	public String[] loadKeyValues() {
+	public String[] loadKeyValues() throws IOException {
 		List<String> result = new LinkedList<String>();
 		try {
 			String line;
 			while ((line = reader.readLine()) != null) {
 				result.add(line);
 			}
-		} catch (IOException ex) {
-			throw new OsmosisRuntimeException("Unable to read from key.value file " + fileName + ".", ex);
 		} finally {
 			cleanup();
 		}
@@ -90,7 +80,7 @@ public class KeyValueFileReader {
 			try {
 				reader.close();
 			} catch (Exception e) {
-				LOG.log(Level.SEVERE, "Unable to close key.value file reader.", e);
+				LOG.log(Level.SEVERE, "Unable to close file reader.", e);
 			} finally {
 				reader = null;
 			}

--- a/tagfilter/src/main/java/org/openstreetmap/osmosis/tagfilter/v0_6/NodeKeyValueFilter.java
+++ b/tagfilter/src/main/java/org/openstreetmap/osmosis/tagfilter/v0_6/NodeKeyValueFilter.java
@@ -2,9 +2,12 @@
 package org.openstreetmap.osmosis.tagfilter.v0_6;
 
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.Map;
 
+import org.openstreetmap.osmosis.core.OsmosisRuntimeException;
 import org.openstreetmap.osmosis.core.container.v0_6.BoundContainer;
 import org.openstreetmap.osmosis.core.container.v0_6.EntityContainer;
 import org.openstreetmap.osmosis.core.container.v0_6.EntityProcessor;
@@ -52,10 +55,18 @@ public class NodeKeyValueFilter implements SinkSource, EntityProcessor {
 	 *            File containing one key-value combination per line
 	 */
 	public NodeKeyValueFilter(File keyValueListFile) {
+		
+		String[] keyValues;
+		try {
+			KeyValueFileReader reader = new KeyValueFileReader(keyValueListFile);
+			keyValues = reader.loadKeyValues();
+		} catch (FileNotFoundException ex) {
+			throw new OsmosisRuntimeException("Unable to find key.value file " + keyValueListFile.getAbsolutePath() + ".", ex);
+		} catch (IOException ex) {
+			throw new OsmosisRuntimeException("Unable to read from key.value file " + keyValueListFile.getAbsolutePath() + ".", ex);
+		}
 
 		allowedKeyValues = new HashSet<String>();
-		KeyValueFileReader reader = new KeyValueFileReader(keyValueListFile);
-		String[] keyValues = reader.loadKeyValues();
 		for (int i = 0; i < keyValues.length; i++) {
 			allowedKeyValues.add(keyValues[i]);
 		}

--- a/tagfilter/src/main/java/org/openstreetmap/osmosis/tagfilter/v0_6/NodeKeyValueFilterFactory.java
+++ b/tagfilter/src/main/java/org/openstreetmap/osmosis/tagfilter/v0_6/NodeKeyValueFilterFactory.java
@@ -17,7 +17,7 @@ import org.openstreetmap.osmosis.core.pipeline.v0_6.SinkSourceManager;
  */
 public class NodeKeyValueFilterFactory extends TaskManagerFactory {
     private static final String ARG_KEY_VALUE_LIST = "keyValueList";
-    private static final String ARG_KEY_VALUE_LIST_File = "keyValueListFile";
+    private static final String ARG_KEY_VALUE_LIST_FILE = "keyValueListFile";
     
 	/**
 	 * {@inheritDoc}
@@ -30,7 +30,7 @@ public class NodeKeyValueFilterFactory extends TaskManagerFactory {
 			String keyValueList = getStringArgument(taskConfig, ARG_KEY_VALUE_LIST);
 			nodeKeyValueFilter = new NodeKeyValueFilter(keyValueList);
 		} else {
-			String keyValueListFile = getStringArgument(taskConfig, ARG_KEY_VALUE_LIST_File);
+			String keyValueListFile = getStringArgument(taskConfig, ARG_KEY_VALUE_LIST_FILE);
 			nodeKeyValueFilter = new NodeKeyValueFilter(new File(keyValueListFile));
 		}
 		

--- a/tagfilter/src/main/java/org/openstreetmap/osmosis/tagfilter/v0_6/WayKeyValueFilter.java
+++ b/tagfilter/src/main/java/org/openstreetmap/osmosis/tagfilter/v0_6/WayKeyValueFilter.java
@@ -2,9 +2,12 @@
 package org.openstreetmap.osmosis.tagfilter.v0_6;
 
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.Map;
 
+import org.openstreetmap.osmosis.core.OsmosisRuntimeException;
 import org.openstreetmap.osmosis.core.container.v0_6.BoundContainer;
 import org.openstreetmap.osmosis.core.container.v0_6.EntityContainer;
 import org.openstreetmap.osmosis.core.container.v0_6.EntityProcessor;
@@ -55,9 +58,17 @@ public class WayKeyValueFilter implements SinkSource, EntityProcessor {
 	 */
 	public WayKeyValueFilter(File keyValueListFile) {
 
+		String[] keyValues;
+		try {
+			KeyValueFileReader reader = new KeyValueFileReader(keyValueListFile);
+			keyValues = reader.loadKeyValues();
+		} catch (FileNotFoundException ex) {
+			throw new OsmosisRuntimeException("Unable to find key.value file " + keyValueListFile.getAbsolutePath() + ".", ex);
+		} catch (IOException ex) {
+			throw new OsmosisRuntimeException("Unable to read from key.value file " + keyValueListFile.getAbsolutePath() + ".", ex);
+		}
+
 		allowedKeyValues = new HashSet<String>();
-		KeyValueFileReader reader = new KeyValueFileReader(keyValueListFile);
-		String[] keyValues = reader.loadKeyValues();
 		for (int i = 0; i < keyValues.length; i++) {
 			allowedKeyValues.add(keyValues[i]);
 		}

--- a/tagfilter/src/main/java/org/openstreetmap/osmosis/tagfilter/v0_6/WayKeyValueFilterFactory.java
+++ b/tagfilter/src/main/java/org/openstreetmap/osmosis/tagfilter/v0_6/WayKeyValueFilterFactory.java
@@ -18,7 +18,7 @@ import org.openstreetmap.osmosis.core.pipeline.v0_6.SinkSourceManager;
  */
 public class WayKeyValueFilterFactory extends TaskManagerFactory {
 	private static final String ARG_KEY_VALUE_LIST = "keyValueList";
-	private static final String ARG_KEY_VALUE_LIST_File = "keyValueListFile";
+	private static final String ARG_KEY_VALUE_LIST_FILE = "keyValueListFile";
 	
 	
 	/**
@@ -29,13 +29,16 @@ public class WayKeyValueFilterFactory extends TaskManagerFactory {
 		WayKeyValueFilter wayKeyValueFilter;
 		
 		if (doesArgumentExist(taskConfig, ARG_KEY_VALUE_LIST)) {
-			String keyValueList = getStringArgument(taskConfig, ARG_KEY_VALUE_LIST,
+			String keyValueList = getStringArgument(taskConfig, ARG_KEY_VALUE_LIST);
+			wayKeyValueFilter = new WayKeyValueFilter(keyValueList);
+		} else if (doesArgumentExist(taskConfig, ARG_KEY_VALUE_LIST_FILE)) {
+			String keyValueListFile = getStringArgument(taskConfig, ARG_KEY_VALUE_LIST_FILE);
+			wayKeyValueFilter = new WayKeyValueFilter(new File(keyValueListFile));
+		} else {
+			String keyValueList = getDefaultStringArgument(taskConfig,
 					"highway.motorway,highway.motorway_link,highway.trunk,highway.trunk_link");
 			wayKeyValueFilter = new WayKeyValueFilter(keyValueList);
-		} else {
-			String keyValueListFile = getStringArgument(taskConfig, ARG_KEY_VALUE_LIST_File);
-			wayKeyValueFilter = new WayKeyValueFilter(new File(keyValueListFile));
-		}		
+		}
 		
 		return new SinkSourceManager(
 			taskConfig.getId(),

--- a/tagfilter/src/test/java/org/openstreetmap/osmosis/tagfilter/common/KeyValueFileReaderTest.java
+++ b/tagfilter/src/test/java/org/openstreetmap/osmosis/tagfilter/common/KeyValueFileReaderTest.java
@@ -1,0 +1,51 @@
+// This software is released into the Public Domain.  See copying.txt for details.
+package org.openstreetmap.osmosis.tagfilter.common;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.osmosis.testutil.AbstractDataTest;
+
+
+/**
+ * Tests for the KeyValueFileReader class.
+ * 
+ * @author Raluca Martinescu
+ */
+public class KeyValueFileReaderTest extends AbstractDataTest {
+
+	/**
+	 * Tests that in case the file does not exist, the KeyValueFileReader
+	 * constructor throws an exception
+	 */
+	@Test
+	public final void testFileNotFound() {
+		File file = new File("non_existing_file.txt");
+		try {
+			new KeyValueFileReader(file);
+			Assert.fail();
+		} catch (FileNotFoundException ex) {
+			Assert.assertTrue(true);
+		} catch (Exception ex) {
+			Assert.fail();
+		}
+	}
+
+
+	/**
+	 * Tests the reading of key-value pairs from the file.
+	 */
+	@Test
+	public final void testLoadKeyValues() {
+		File file = dataUtils.createDataFile("v0_6/allowed-key-values.txt");
+		try {
+			String[] expected = { "box_type.lamp_box", "box_type.wall" };
+			String[] actual = new KeyValueFileReader(file).loadKeyValues();
+			Assert.assertArrayEquals(expected, actual);
+		} catch (Exception ex) {
+			Assert.fail();
+		}
+	}
+}

--- a/tagfilter/src/test/java/org/openstreetmap/osmosis/tagfilter/v0_6/NodeKeyValueFilterTest.java
+++ b/tagfilter/src/test/java/org/openstreetmap/osmosis/tagfilter/v0_6/NodeKeyValueFilterTest.java
@@ -1,0 +1,69 @@
+// This software is released into the Public Domain.  See copying.txt for details.
+package org.openstreetmap.osmosis.tagfilter.v0_6;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Test;
+import org.openstreetmap.osmosis.core.Osmosis;
+import org.openstreetmap.osmosis.testutil.AbstractDataTest;
+
+
+/**
+ * Tests for the NodeKeyValueFilter class.
+ * 
+ * @author Raluca Martinescu
+ */
+public class NodeKeyValueFilterTest extends AbstractDataTest {	
+
+	
+	/**
+	 * Tests the node key-value filter when allowed value pairs are read from
+	 * comma separated list of values.
+	 * 
+	 * @throws IOException
+	 *             if file manipulation fails.
+	 */
+	@Test
+	public final void testNodeKeyValueFilterFromList() throws IOException {
+		testNodeKeyValueFilter("keyValueList=box_type.lamp_box,box_type.wall");
+	}
+
+
+	/**
+	 * Tests the node key-value filter when allowed value pairs are read from
+	 * file.
+	 * 
+	 * @throws IOException
+	 *             if file manipulation fails.
+	 */
+	@Test
+	public final void testNodeKeyValueFilterFromFile() throws IOException {
+		File allowedPairs = dataUtils.createDataFile("v0_6/allowed-key-values.txt");
+		testNodeKeyValueFilter("keyValueListFile=" + allowedPairs.getPath());
+	}
+
+
+	private void testNodeKeyValueFilter(String keyValueListOption) throws IOException {
+
+		File inputFile = dataUtils.createDataFile("v0_6/node-key-value-filter-snapshot.osm");
+		File expectedResultFile = dataUtils.createDataFile("v0_6/node-key-value-filter-expected.osm");
+		File outputFile = dataUtils.newFile();
+		
+		// filter by key-value pairs
+		Osmosis.run(
+			new String [] {
+				"-q",					
+				"--read-xml-0.6",
+				inputFile.getPath(),
+				"--node-key-value",
+				keyValueListOption,
+				"--write-xml-0.6",
+				outputFile.getPath()
+			}
+		);
+					
+		// Validate that the output file matches the expected file
+		dataUtils.compareFiles(expectedResultFile, outputFile);
+	}
+}

--- a/tagfilter/src/test/java/org/openstreetmap/osmosis/tagfilter/v0_6/WayKeyValueFilterTest.java
+++ b/tagfilter/src/test/java/org/openstreetmap/osmosis/tagfilter/v0_6/WayKeyValueFilterTest.java
@@ -1,0 +1,71 @@
+// This software is released into the Public Domain.  See copying.txt for details.
+package org.openstreetmap.osmosis.tagfilter.v0_6;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openstreetmap.osmosis.core.Osmosis;
+import org.openstreetmap.osmosis.testutil.AbstractDataTest;
+
+
+/**
+ * Tests for the WayKeyValueFilter class.
+ * 
+ * @author Raluca Martinescu
+ */
+public class WayKeyValueFilterTest extends AbstractDataTest {
+
+	/**
+	 * Tests the way key-value filter when allowed value pairs are read from
+	 * comma separated list of values.
+	 * 
+	 * @throws IOException
+	 *             if file manipulation fails.
+	 */
+	@Test
+	public final void testWayKeyValueFilterFromList() throws IOException {
+		testWayKeyValueFilter("keyValueList=box_type.lamp_box,box_type.wall");
+	}
+
+
+	/**
+	 * Tests the way key-value filter when allowed value pairs are read from
+	 * file.
+	 * 
+	 * @throws IOException
+	 *             if file manipulation fails.
+	 */
+	@Test
+	public final void testWayKeyValueFilterFromFile() throws IOException {
+		File allowedPairs = dataUtils.createDataFile("v0_6/allowed-key-values.txt");
+		testWayKeyValueFilter("keyValueListFile=" + allowedPairs.getPath());
+	}
+
+
+	private void testWayKeyValueFilter(String keyValueListOption) throws IOException {
+
+		File inputFile = dataUtils.createDataFile("v0_6/way-key-value-filter-snapshot.osm");
+		File expectedResultFile = dataUtils.createDataFile("v0_6/way-key-value-filter-expected.osm");
+		File outputFile = dataUtils.newFile();
+		
+		// filter by key-value pairs
+		Osmosis.run(
+			new String [] {
+				"-q",					
+				"--read-xml-0.6",
+				inputFile.getPath(),
+				"--way-key-value",
+				keyValueListOption,
+				"--write-xml-0.6",
+				outputFile.getPath()
+			}
+		);
+					
+		// Validate that the output file matches the expected file
+		dataUtils.compareFiles(expectedResultFile, outputFile);
+	}
+}

--- a/tagfilter/src/test/resources/data/template/v0_6/allowed-key-values.txt
+++ b/tagfilter/src/test/resources/data/template/v0_6/allowed-key-values.txt
@@ -1,0 +1,2 @@
+box_type.lamp_box
+box_type.wall

--- a/tagfilter/src/test/resources/data/template/v0_6/node-key-value-filter-expected.osm
+++ b/tagfilter/src/test/resources/data/template/v0_6/node-key-value-filter-expected.osm
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" generator="Osmosis %VERSION%">
+  <bounds minlon="-180.00000" minlat="-90.00000" maxlon="180.00000" maxlat="90.00000" origin="Osmosis %VERSION%"/>
+  <node id="19" version="2" timestamp="2010-07-07T07:51:18Z" uid="10" user="user1" lat="51.9458753" lon="-0.20698">
+    <tag k="amenity" v="post_box"/>
+    <tag k="box_type" v="lamp_box"/>
+    <tag k="last_collection_mf" v="1630"/>
+    <tag k="last_collection_sat" v="0945"/>
+    <tag k="ref" v="SG4 90"/>
+  </node>
+  <node id="33" version="2" timestamp="2010-12-27T18:09:50Z" uid="30" user="user1" lat="52.5336725" lon="0.8310367">
+    <tag k="amenity" v="post_box"/>
+    <tag k="box_type" v="wall"/>
+    <tag k="collection_times" v="Mo-Fr 17:30; Sa 11:30"/>
+    <tag k="note" v="in brick pillar being bus shelter"/>
+    <tag k="ref" v="IP24 3228"/>
+    <tag k="royal_cypher" v="EIIR"/>
+  </node>
+</osm>

--- a/tagfilter/src/test/resources/data/template/v0_6/node-key-value-filter-snapshot.osm
+++ b/tagfilter/src/test/resources/data/template/v0_6/node-key-value-filter-snapshot.osm
@@ -1,0 +1,53 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" generator="Osmosis %VERSION%">
+  <bounds minlon="-180.00000" minlat="-90.00000" maxlon="180.00000" maxlat="90.00000" origin="Osmosis %VERSION%"/>
+  <node id="13" version="2" timestamp="2011-05-08T22:06:06Z" uid="134914" user="user1" lat="51.3731042" lon="9.5130058">
+    <tag k="highway" v="bus_stop"/>
+    <tag k="name" v="Bleichplatz"/>
+    <tag k="shelter" v="yes"/>
+    <tag k="uic_ref" v="713807"/>
+  </node>
+  <node id="19" version="2" timestamp="2010-07-07T07:51:18Z" uid="10" user="user1" lat="51.9458753" lon="-0.20698">
+    <tag k="amenity" v="post_box"/>
+    <tag k="box_type" v="lamp_box"/>
+    <tag k="last_collection_mf" v="1630"/>
+    <tag k="last_collection_sat" v="0945"/>
+    <tag k="ref" v="SG4 90"/>
+  </node>
+  <node id="22" version="4" timestamp="2010-07-31T21:53:23Z" uid="20" user="user1" lat="51.938183" lon="-0.268633">
+    <tag k="amenity" v="post_box"/>
+    <tag k="box_type" v="pillar_box_k"/>
+    <tag k="collection_times" v="Mo-Fr 17:30; Sa 12:00"/>
+    <tag k="cypher" v="EIIR"/>
+    <tag k="ref" v="SG4 24"/>
+  </node>  
+  <node id="33" version="2" timestamp="2010-12-27T18:09:50Z" uid="30" user="user1" lat="52.5336725" lon="0.8310367">
+    <tag k="amenity" v="post_box"/>
+    <tag k="box_type" v="wall"/>
+    <tag k="collection_times" v="Mo-Fr 17:30; Sa 11:30"/>
+    <tag k="note" v="in brick pillar being bus shelter"/>
+    <tag k="ref" v="IP24 3228"/>
+    <tag k="royal_cypher" v="EIIR"/>
+  </node>  
+  <way id="1" version="10" timestamp="2008-01-02T03:04:05Z" uid="10" user="user1">
+    <nd ref="13"/>
+    <nd ref="19"/>
+    <nd ref="22"/>
+    <tag k="created_by" v="Me1"/>
+  </way>
+  <way id="2" version="11" timestamp="2008-01-02T03:04:05Z" uid="20" user="user1">
+    <nd ref="19"/>
+    <nd ref="22"/>
+    <nd ref="33"/>
+    <tag k="other_tag_1c" v="other tag before"/>
+    <tag k="created_by" v="Me1"/>
+    <tag k="other_tag_1c" v="other tag after"/>
+  </way>
+  <relation id="1" version="10" timestamp="2008-01-02T03:04:05Z" uid="10" user="user1">
+    <member type="node" ref="33" role="noderole"/>
+    <member type="way" ref="1" role="wayrole1"/>
+    <member type="way" ref="2" role="wayrole2"/>
+    <tag k="other_tag_1d" v="other tag before"/>
+    <tag k="type" v="myrelation"/>
+  </relation>
+</osm>

--- a/tagfilter/src/test/resources/data/template/v0_6/way-key-value-filter-expected.osm
+++ b/tagfilter/src/test/resources/data/template/v0_6/way-key-value-filter-expected.osm
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" generator="Osmosis %VERSION%">
+  <bounds minlon="-180.00000" minlat="-90.00000" maxlon="180.00000" maxlat="90.00000" origin="Osmosis %VERSION%"/>
+  <node id="13" version="2" timestamp="2011-05-08T22:06:06Z" uid="134914" user="user1" lat="51.3731042" lon="9.5130058"/>
+  <node id="19" version="2" timestamp="2010-07-07T07:51:18Z" uid="10" user="user1" lat="51.9458753" lon="-0.20698"/>
+  <node id="22" version="4" timestamp="2010-07-31T21:53:23Z" uid="20" user="user1" lat="51.938183" lon="-0.268633"/>
+  <node id="33" version="2" timestamp="2010-12-27T18:09:50Z" uid="30" user="user1" lat="52.5336725" lon="0.8310367"/>
+  <way id="2" version="11" timestamp="2008-01-02T03:04:05Z" uid="20" user="user1">
+    <nd ref="19"/>
+    <nd ref="22"/>
+    <nd ref="33"/>
+    <tag k="box_type" v="lamp_box"/>
+    <tag k="created_by" v="Me1"/>
+    <tag k="other_tag_1c" v="other tag after"/>
+  </way>
+  <way id="3" version="11" timestamp="2008-01-02T03:04:05Z" uid="20" user="user1">
+    <nd ref="13"/>
+    <nd ref="22"/>
+    <nd ref="33"/>
+    <tag k="box_type" v="wall"/>
+  </way>
+  <relation id="1" version="10" timestamp="2008-01-02T03:04:05Z" uid="10" user="user1">
+    <member type="node" ref="3" role="noderole"/>
+    <member type="way" ref="1" role="wayrole1"/>
+    <member type="way" ref="2" role="wayrole2"/>
+    <tag k="other_tag_1d" v="other tag before"/>
+    <tag k="type" v="myrelation"/>
+  </relation>
+</osm>

--- a/tagfilter/src/test/resources/data/template/v0_6/way-key-value-filter-snapshot.osm
+++ b/tagfilter/src/test/resources/data/template/v0_6/way-key-value-filter-snapshot.osm
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" generator="Osmosis %VERSION%">
+  <bounds minlon="-180.00000" minlat="-90.00000" maxlon="180.00000" maxlat="90.00000" origin="Osmosis %VERSION%"/>
+  <node id="13" version="2" timestamp="2011-05-08T22:06:06Z" uid="134914" user="user1" lat="51.3731042" lon="9.5130058"/>
+  <node id="19" version="2" timestamp="2010-07-07T07:51:18Z" uid="10" user="user1" lat="51.9458753" lon="-0.20698"/>
+  <node id="22" version="4" timestamp="2010-07-31T21:53:23Z" uid="20" user="user1" lat="51.938183" lon="-0.268633"/> 
+  <node id="33" version="2" timestamp="2010-12-27T18:09:50Z" uid="30" user="user1" lat="52.5336725" lon="0.8310367"/>
+  <way id="1" version="10" timestamp="2008-01-02T03:04:05Z" uid="10" user="user1">
+    <nd ref="13"/>
+    <nd ref="19"/>
+    <nd ref="22"/>
+    <tag k="created_by" v="Me1"/>
+  </way>
+  <way id="2" version="11" timestamp="2008-01-02T03:04:05Z" uid="20" user="user1">
+    <nd ref="19"/>
+    <nd ref="22"/>
+    <nd ref="33"/>
+    <tag k="box_type" v="lamp_box"/>
+    <tag k="created_by" v="Me1"/>
+    <tag k="other_tag_1c" v="other tag after"/>
+  </way>
+  <way id="3" version="11" timestamp="2008-01-02T03:04:05Z" uid="20" user="user1">
+    <nd ref="13"/>
+    <nd ref="22"/>
+    <nd ref="33"/>
+    <tag k="box_type" v="wall"/>
+  </way>
+  <way id="4" version="11" timestamp="2008-01-02T03:04:05Z" uid="20" user="user1">
+    <nd ref="13"/>
+    <nd ref="22"/>
+    <nd ref="33"/>
+    <tag k="box_type" v="pillar_box_k"/>
+  </way>   
+  <relation id="1" version="10" timestamp="2008-01-02T03:04:05Z" uid="10" user="user1">
+    <member type="node" ref="3" role="noderole"/>
+    <member type="way" ref="1" role="wayrole1"/>
+    <member type="way" ref="2" role="wayrole2"/>
+    <tag k="other_tag_1d" v="other tag before"/>
+    <tag k="type" v="myrelation"/>
+  </relation>
+</osm>


### PR DESCRIPTION
For the --node-key-value and --way-key-value command line options I added also the possibility to read the key.value combinations from an external file, specifying the "keyValueListFile=<file_path>" option (if "keyValueList" does not exist, "keyValueListFile" is read instead). 

The reason for this change is that the initial way worked very good if you only needed to filter by couple of key.value combinations, but if you need to do this by, let's say 100 combinations, it's much more convenient to put it in a file.

Please review the code.
