### PR TITLE
Point to the up-to-date wiki page

### DIFF
--- a/package/bin/osmosis
+++ b/package/bin/osmosis
@@ -73,7 +73,7 @@ osmosis --read-xml file="planetin.osm" --write-xml file="planetout.osm"
 
 osmosis --read-xml file="planetin.osm" outPipe.0="mypipe" --write-xml file="planetout.osm" inPipe.0="mypipe"
 
-Full usage details are available at: http://wiki.openstreetmap.org/wiki/Osmosis/DetailedUsage 
+Full usage details are available at: http://wiki.openstreetmap.org/wiki/Osmosis/Detailed_Usage
 
 EOF
 exit 1


### PR DESCRIPTION
Osmosis/DetailedUsage was still redirecting to the 0.39 page, while Osmosis/Detailed_Usage seems to be kept up to date. Point the user to this page instead.
