### PR TITLE
wrap JAVACMD with quotes in case of spaces in path

### DIFF
--- a/package/bin/osmosis.bat
+++ b/package/bin/osmosis.bat
@@ -36,6 +36,6 @@ cd /D %SAVEDIR%
 
 set MAINCLASS=org.codehaus.classworlds.Launcher
 set PLEXUS_CP=%MYAPP_HOME%\lib\default\plexus-classworlds-2.4.jar
-SET EXEC=%JAVACMD% %JAVACMD_OPTIONS% -cp "%PLEXUS_CP%" -Dapp.home="%MYAPP_HOME%" -Dclassworlds.conf="%MYAPP_HOME%\config\plexus.conf" %MAINCLASS%  %OSMOSIS_OPTIONS% %*
+SET EXEC="%JAVACMD%" %JAVACMD_OPTIONS% -cp "%PLEXUS_CP%" -Dapp.home="%MYAPP_HOME%" -Dclassworlds.conf="%MYAPP_HOME%\config\plexus.conf" %MAINCLASS%  %OSMOSIS_OPTIONS% %*
 
 %EXEC%


### PR DESCRIPTION
When `JAVACMD` contains a path with spaces (such as `C:\Program Files (x86)\Java\jre7\bin\java`), the `EXEC` line fails to run.

This fix simply wraps `%JAVACMD%` with quotes when `EXEC` is constructed.
