### PR TITLE
Set 'User-Agent' header on HTTP connections.

### DIFF
--- a/osmosis-replication/src/main/java/org/openstreetmap/osmosis/replication/common/ServerStateReader.java
+++ b/osmosis-replication/src/main/java/org/openstreetmap/osmosis/replication/common/ServerStateReader.java
@@ -16,6 +16,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.openstreetmap.osmosis.core.OsmosisRuntimeException;
+import org.openstreetmap.osmosis.core.OsmosisConstants;
 
 
 /**
@@ -92,6 +93,7 @@ public class ServerStateReader {
 			URLConnection connection = stateUrl.openConnection();
 			connection.setReadTimeout(15 * 60 * 1000); // timeout 15 minutes
 			connection.setConnectTimeout(15 * 60 * 1000); // timeout 15 minutes
+			connection.setRequestProperty("User-Agent", "Osmosis/" + OsmosisConstants.VERSION);
 			stateStream = connection.getInputStream();
 			
 			reader = new BufferedReader(new InputStreamReader(stateStream));

--- a/osmosis-replication/src/main/java/org/openstreetmap/osmosis/replication/v0_6/BaseReplicationDownloader.java
+++ b/osmosis-replication/src/main/java/org/openstreetmap/osmosis/replication/v0_6/BaseReplicationDownloader.java
@@ -18,6 +18,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.openstreetmap.osmosis.core.OsmosisRuntimeException;
+import org.openstreetmap.osmosis.core.OsmosisConstants;
 import org.openstreetmap.osmosis.core.task.common.RunnableTask;
 import org.openstreetmap.osmosis.core.util.FileBasedLock;
 import org.openstreetmap.osmosis.core.util.PropertiesPersister;
@@ -104,6 +105,7 @@ public abstract class BaseReplicationDownloader implements RunnableTask {
 			URLConnection connection = changesetUrl.openConnection();
 			connection.setReadTimeout(15 * 60 * 1000); // timeout 15 minutes
 			connection.setConnectTimeout(15 * 60 * 1000); // timeout 15 minutes
+			connection.setRequestProperty("User-Agent", "Osmosis/" + OsmosisConstants.VERSION);
 			inputStream = connection.getInputStream();
 			source = new BufferedInputStream(inputStream, 65536);
 			

--- a/osmosis-replication/src/main/java/org/openstreetmap/osmosis/replication/v0_6/IntervalDownloader.java
+++ b/osmosis-replication/src/main/java/org/openstreetmap/osmosis/replication/v0_6/IntervalDownloader.java
@@ -20,6 +20,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.openstreetmap.osmosis.core.OsmosisRuntimeException;
+import org.openstreetmap.osmosis.core.OsmosisConstants;
 import org.openstreetmap.osmosis.core.merge.common.ConflictResolutionMethod;
 import org.openstreetmap.osmosis.core.pipeline.common.TaskRunner;
 import org.openstreetmap.osmosis.core.task.v0_6.ChangeSink;
@@ -111,6 +112,7 @@ public class IntervalDownloader implements RunnableChangeSource {
 			URLConnection connection = timestampUrl.openConnection();
 			connection.setReadTimeout(15 * 60 * 1000); // timeout 15 minutes
 			connection.setConnectTimeout(15 * 60 * 1000); // timeout 15 minutes
+			connection.setRequestProperty("User-Agent", "Osmosis/" + OsmosisConstants.VERSION);
 			timestampStream = connection.getInputStream();
 			
 			reader = new BufferedReader(new InputStreamReader(timestampStream));

--- a/osmosis-xml/src/main/java/org/openstreetmap/osmosis/xml/v0_6/XmlChangeUploader.java
+++ b/osmosis-xml/src/main/java/org/openstreetmap/osmosis/xml/v0_6/XmlChangeUploader.java
@@ -122,6 +122,7 @@ public class XmlChangeUploader implements ChangeSink {
             System.err.println("DEBUG: URL= " + url.toString());
             HttpURLConnection httpCon = (HttpURLConnection)
                                       url.openConnection();
+            httpCon.setRequestProperty("User-Agent", "Osmosis/" + OsmosisConstants.VERSION);
 
             // we do not use Authenticator.setDefault()
             // here to stay thread-safe.

--- a/osmosis-xml/src/main/java/org/openstreetmap/osmosis/xml/v0_6/XmlDownloader.java
+++ b/osmosis-xml/src/main/java/org/openstreetmap/osmosis/xml/v0_6/XmlDownloader.java
@@ -19,6 +19,7 @@ import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
 import org.openstreetmap.osmosis.core.OsmosisRuntimeException;
+import org.openstreetmap.osmosis.core.OsmosisConstants;
 import org.openstreetmap.osmosis.core.container.v0_6.BoundContainer;
 import org.openstreetmap.osmosis.core.domain.v0_6.Bound;
 import org.openstreetmap.osmosis.core.task.v0_6.RunnableSource;
@@ -235,6 +236,7 @@ public class XmlDownloader implements RunnableSource {
         url = new URL(pUrlStr);
         myActiveConnection = (HttpURLConnection) url.openConnection();
 
+        myActiveConnection.setRequestProperty("User-Agent", "Osmosis/" + OsmosisConstants.VERSION);
         myActiveConnection.setRequestProperty("Accept-Encoding", "gzip, deflate");
 
         responseCode = myActiveConnection.getResponseCode();


### PR DESCRIPTION
Setting the 'User-Agent' header helps server administrators identify which traffic is coming from Osmosis, and helps avoid some disadvantages of using the plain Java identifier such as setting off poorly configured IDS warnings.
