### PR TITLE
replicate_osm_file.sh: Don't exit with negative status.

### DIFF
--- a/package/script/contrib/replicate_osm_file.sh
+++ b/package/script/contrib/replicate_osm_file.sh
@@ -23,11 +23,13 @@ CMD="osmosis -q"
 # Launch the osmosis process.
 $CMD --read-change-interval $WORKING_DIRECTORY --read-xml $OSM_FILE --apply-change --bounding-box left=$LEFT bottom=$BOTTOM right=$RIGHT top=$TOP --write-xml $TEMP_OSM_FILE
 
+STATUS=$?
+
 # Verify that osmosis ran successfully.
-if [ "$?" -ne "0" ]; then
+if [ "$STATUS" -ne "0" ]; then
 	
 	echo "Osmosis failed, aborting."
-	exit -1
+	exit $STATUS
 	
 fi
 


### PR DESCRIPTION
Exit statuses fall between 0 and 255.

Exit using the osmosis status in case it fails instead of -1.

This issue was reported in [Debian Bug#772355](https://bugs.debian.org/772355)
