### PR TITLE
Fix query for retrieving way-nodes in pgsnapshot module

### DIFF
--- a/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/impl/EntityFeatureDao.java
+++ b/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/impl/EntityFeatureDao.java
@@ -51,7 +51,7 @@ public class EntityFeatureDao<Tef extends Storeable, Tdb extends DbFeature<Tef>>
 	 * @return All instances of this feature type for the entity.
 	 */
 	public Collection<Tdb> getAll(long entityId) {
-		return jdbcTemplate.query(entityFeatureMapper.getSqlSelect("", true, true), entityFeatureMapper.getRowMapper());
+		return jdbcTemplate.query(entityFeatureMapper.getSqlSelect("", true, true), new Object[] { entityId }, entityFeatureMapper.getRowMapper());
 	}
 	
 	

--- a/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/impl/WayNodeMapper.java
+++ b/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/impl/WayNodeMapper.java
@@ -48,7 +48,7 @@ public class WayNodeMapper extends EntityFeatureMapper<DbOrderedFeature<WayNode>
 				.append("s e ON f.").append(getParentEntityName()).append("_id = e.id");
 		}
 		if (filterByEntityId) {
-			resultSql.append(" WHERE entity_id = ?");
+			resultSql.append(" WHERE way_id = ?");
 		}
 		if (orderBy) {
 			resultSql.append(getSqlDefaultOrderBy());


### PR DESCRIPTION
We're using the osmosis-pgsnapshot module to walk through Way entities in our OSM database, and we ran into two problems:

* PostgreSQL didn't like that the field alias "entity_id" was being used in the "where" clause of the SQL statement since the "select" portion of the statement is processed last in the query.

* The entity ID wasn't being passed into the Spring JDBC template in the call to getAll() when executing the query, so the query ended up with a literal '?' in the SQL statement that was being executed.

Both of those problems are addressed in the commit.