### PR TITLE
Fix crash when read-replication-lag humanReadable for <1 min lag

### DIFF
--- a/osmosis-replication/src/main/java/org/openstreetmap/osmosis/replication/v0_6/ReplicationLagReader.java
+++ b/osmosis-replication/src/main/java/org/openstreetmap/osmosis/replication/v0_6/ReplicationLagReader.java
@@ -119,10 +119,13 @@ public class ReplicationLagReader implements RunnableTask {
 				);
 				
 			} else {
+				Object[] args = {
+					new Long(lag)
+				};
 				
 				// just some seconds
 				System.out.println(
-					new MessageFormat("{0} second(s)").format(lag)
+					new MessageFormat("{0} second(s)").format(args)
 				);
 				
 			}


### PR DESCRIPTION
There is a bug when you try `--read-replication-lag` and pass in `humanReadable=yes` and the lag is less than 1 minute. It causes an uncaught exception and crash. The problem is MessageFormat isn't called correctly, and this patch fixes this.

I am not knowledgeable about Java, so I am unsure how to add a unittest for this. I have reproduced the problem locally with this command:

     export NOW=$(date -d "30 seconds ago" -u -Iseconds) ; sed -i "s/timestamp=.*/timestamp=$NOW/g" /tmp/osm/state.txt && ./package/bin/osmosis --read-replication-lag workingDirectory=/tmp/osm humanReadable=yes

where `/tmp/osm` has been set up as a replication working directory, and any old `state.txt` file has been copied from somewhere. If you get a crash & java stacktrace, then that's the bug.