### PR TITLE
Update replication urls to match current planet.osm.org layout

### DIFF
--- a/osmosis-replication/src/main/resources/org/openstreetmap/osmosis/replication/v0_6/impl/intervalConfiguration.txt
+++ b/osmosis-replication/src/main/resources/org/openstreetmap/osmosis/replication/v0_6/impl/intervalConfiguration.txt
@@ -1,5 +1,5 @@
 # The URL of the directory containing change files.
-baseUrl=http://planet.openstreetmap.org/hourly
+baseUrl=http://planet.openstreetmap.org/replication/hour
 
 # The length of an extraction interval in seconds (3600 = 1 hour).
 intervalLength=3600

--- a/osmosis-replication/src/main/resources/org/openstreetmap/osmosis/replication/v0_6/impl/replicationDownloaderConfiguration.txt
+++ b/osmosis-replication/src/main/resources/org/openstreetmap/osmosis/replication/v0_6/impl/replicationDownloaderConfiguration.txt
@@ -1,5 +1,5 @@
 # The URL of the directory containing change files.
-baseUrl=http://planet.openstreetmap.org/minute-replicate
+baseUrl=http://planet.openstreetmap.org/replication/minute
 
 # Defines the maximum time interval in seconds to download in a single invocation.
 # Setting to 0 disables this feature.

--- a/osmosis-replication/src/main/resources/org/openstreetmap/osmosis/replication/v0_6/impl/replicationFileMergerConfiguration.txt
+++ b/osmosis-replication/src/main/resources/org/openstreetmap/osmosis/replication/v0_6/impl/replicationFileMergerConfiguration.txt
@@ -1,5 +1,5 @@
 # The URL of the directory containing change files.
-baseUrl=http://planet.openstreetmap.org/minute-replicate
+baseUrl=http://planet.openstreetmap.org/replication/minute
 
 # The length of an extraction interval in seconds (3600 = 1 hour).
 intervalLength=60


### PR DESCRIPTION
The URL for minutely (etc.) replication has changed on planet.openstreetmap.org. Rather than `http://planet.openstreetmap.org/minute-replicate` it's now `http://planet.openstreetmap.org/replication/minute` (etc.). When using `--read-replication-interval-init`, the `configuration.txt` should have the correct URLs.