### PR TITLE
respect the environment variable of proxy setting

### DIFF
--- a/osmosis-replication/src/main/java/org/openstreetmap/osmosis/replication/common/ServerStateReader.java
+++ b/osmosis-replication/src/main/java/org/openstreetmap/osmosis/replication/common/ServerStateReader.java
@@ -18,6 +18,10 @@ import java.util.logging.Logger;
 import org.openstreetmap.osmosis.core.OsmosisRuntimeException;
 import org.openstreetmap.osmosis.core.OsmosisConstants;
 
+import java.net.URI;
+import java.net.Authenticator;
+import java.net.MalformedURLException;
+import java.net.PasswordAuthentication;
 
 /**
  * Retrieves replication state files from the server hosting replication data.
@@ -64,6 +68,26 @@ public class ServerStateReader {
 		return getServerState(baseUrl, sequenceFormatter.getFormattedName(sequenceNumber, SEQUENCE_STATE_FILE_SUFFIX));
 	}
 
+	// environment variable: export http_proxy="http://USER:PASSWORD@HOST:PORT"
+	public static Map<String,String> getEnvProxy(String envvar)
+	{
+	Map<String,String> proxy = new HashMap<String,String>();
+	String envproxy = System.getenv(envvar);
+	if (envproxy != null) {
+	    URI uri = URI.create(envproxy);
+	    proxy.put("HOST", uri.getHost());
+	    proxy.put("PORT", Integer.toString(uri.getPort()));
+	    String userinfo = uri.getUserInfo();
+	    if (userinfo != null) {
+	        String[] userpassinfo = userinfo.split(":", 0);
+	        proxy.put("USER", userpassinfo[0]);
+	        if (userpassinfo.length > 1) {
+	            proxy.put("PASSWORD", userpassinfo[1]);
+	        }
+	    }
+	}
+	return proxy;
+	}
 
 	/**
 	 * Retrieves the specified state from the server.
@@ -84,6 +108,21 @@ public class ServerStateReader {
 			throw new OsmosisRuntimeException("The server timestamp URL could not be created.", e);
 		}
 		
+		final Map<String,String> proxy = getEnvProxy("http_proxy");
+	        if (proxy.containsKey("HOST")) {
+	            System.setProperty("proxySet", "true");
+	            System.setProperty("proxyHost", proxy.get("HOST"));
+	            System.setProperty("proxyPort", proxy.get("PORT"));
+	            if (proxy.containsKey("USER")) {
+	                Authenticator.setDefault(new Authenticator() {
+	                    @Override
+	                    protected PasswordAuthentication getPasswordAuthentication() {
+	                        return new PasswordAuthentication(proxy.get("USER"), proxy.get("PASSWORD").toCharArray());
+	                    }
+	                });
+	            }
+	        }
+
 		try {
 			BufferedReader reader;
 			Properties stateProperties;

--- a/osmosis-replication/src/main/java/org/openstreetmap/osmosis/replication/v0_6/IntervalDownloader.java
+++ b/osmosis-replication/src/main/java/org/openstreetmap/osmosis/replication/v0_6/IntervalDownloader.java
@@ -92,7 +92,6 @@ public class IntervalDownloader implements RunnableChangeSource {
 	public void setChangeSink(ChangeSink changeSink) {
 		this.changeSink = changeSink;
 	}
-	
 
 	public static Map<String,String> getEnvProxy(String envvar)
 	{
@@ -130,7 +129,7 @@ public class IntervalDownloader implements RunnableChangeSource {
 		} catch (MalformedURLException e) {
 			throw new OsmosisRuntimeException("The server timestamp URL could not be created.", e);
 		}
-	
+
 	        final Map<String,String> proxy = getEnvProxy("http_proxy");
 	        if (proxy.containsKey("HOST")) {
 	            System.setProperty("proxySet", "true");
@@ -264,7 +263,7 @@ public class IntervalDownloader implements RunnableChangeSource {
 	 * to the output task.
 	 */
 	private void download() {
-		inputstreamreadervalDownloaderConfiguration configuration;
+		IntervalDownloaderConfiguration configuration;
 		TimestampTracker timestampTracker;
 		ChangesetFileNameFormatter fileNameFormatter;
 		Date currentTime;

--- a/osmosis-replication/src/main/java/org/openstreetmap/osmosis/replication/v0_6/IntervalDownloader.java
+++ b/osmosis-replication/src/main/java/org/openstreetmap/osmosis/replication/v0_6/IntervalDownloader.java
@@ -34,6 +34,12 @@ import org.openstreetmap.osmosis.set.v0_6.ChangeMerger;
 import org.openstreetmap.osmosis.xml.common.CompressionMethod;
 import org.openstreetmap.osmosis.xml.v0_6.XmlChangeReader;
 
+import java.util.Map;
+import java.util.HashMap;
+import java.net.URI;
+import java.net.Authenticator;
+import java.net.MalformedURLException;
+import java.net.PasswordAuthentication;
 
 /**
  * Downloads a set of change files from a HTTP server, and merges them into a
@@ -87,7 +93,27 @@ public class IntervalDownloader implements RunnableChangeSource {
 		this.changeSink = changeSink;
 	}
 	
-	
+
+	public static Map<String,String> getEnvProxy(String envvar)
+	{
+	Map<String,String> proxy = new HashMap<String,String>();
+	String envproxy = System.getenv(envvar);
+	if (envproxy != null) {
+	    URI uri = URI.create(envproxy);
+	    proxy.put("HOST", uri.getHost());
+	    proxy.put("PORT", Integer.toString(uri.getPort()));
+	    String userinfo = uri.getUserInfo();
+	    if (userinfo != null) {
+	        String[] userpassinfo = userinfo.split(":", 0);
+	        proxy.put("USER", userpassinfo[0]);
+	        if (userpassinfo.length > 1) {
+	            proxy.put("PASSWORD", userpassinfo[1]);
+	        }
+	    }
+	}
+	return proxy;
+	}
+
 	/**
 	 * Retrieves the latest timestamp from the server.
 	 * 
@@ -104,6 +130,21 @@ public class IntervalDownloader implements RunnableChangeSource {
 		} catch (MalformedURLException e) {
 			throw new OsmosisRuntimeException("The server timestamp URL could not be created.", e);
 		}
+	
+	        final Map<String,String> proxy = getEnvProxy("http_proxy");
+	        if (proxy.containsKey("HOST")) {
+	            System.setProperty("proxySet", "true");
+	            System.setProperty("proxyHost", proxy.get("HOST"));
+	            System.setProperty("proxyPort", proxy.get("PORT"));
+	            if (proxy.containsKey("USER")) {
+	                Authenticator.setDefault(new Authenticator() {
+	                    @Override
+	                    protected PasswordAuthentication getPasswordAuthentication() {
+	                        return new PasswordAuthentication(proxy.get("USER"), proxy.get("PASSWORD").toCharArray());
+	                    }
+	                });
+	            }
+	        }
 		
 		try {
 			BufferedReader reader;
@@ -223,7 +264,7 @@ public class IntervalDownloader implements RunnableChangeSource {
 	 * to the output task.
 	 */
 	private void download() {
-		IntervalDownloaderConfiguration configuration;
+		inputstreamreadervalDownloaderConfiguration configuration;
 		TimestampTracker timestampTracker;
 		ChangesetFileNameFormatter fileNameFormatter;
 		Date currentTime;


### PR DESCRIPTION
I would like osmosis to respect the environment variable of proxy setting:

```
http_proxy="http://USER:PASSWORD@HOST:PORT"
```
