### PR TITLE
Add support for postgresql schema on --write-pgsql option

### DIFF
--- a/db-server/docker-start.sh
+++ b/db-server/docker-start.sh
@@ -27,6 +27,9 @@ if [ ! "$(ls -A $DATADIR)" ]; then
 	su postgres sh -lc "postgres --single -jE" <<-EOSQL
 		CREATE DATABASE pgosmsnap06_test OWNER osm;
 	EOSQL
+	su postgres sh -lc "postgres --single -jE" <<-EOSQL
+		CREATE DATABASE pgosmsnap06_test_with_schema OWNER osm;
+	EOSQL
 
 	# Create the apidb database owned by osm.
 	su postgres sh -lc "postgres --single -jE" <<-EOSQL
@@ -47,6 +50,18 @@ if [ ! "$(ls -A $DATADIR)" ]; then
 
 	# Configure the pgosmsnap06_test database as the OSM user.
 	su postgres sh -lc "psql -U osm pgosmsnap06_test" <<-EOSQL
+		CREATE EXTENSION hstore;
+		CREATE EXTENSION postgis;
+		\i /install/script/pgsnapshot_schema_0.6.sql
+		\i /install/script/pgsnapshot_schema_0.6_action.sql
+		\i /install/script/pgsnapshot_schema_0.6_bbox.sql
+		\i /install/script/pgsnapshot_schema_0.6_linestring.sql
+	EOSQL
+
+	# Configure the pgosmsnap06_test_with_schema database as the OSM user.
+	su postgres sh -lc "psql -U osm pgosmsnap06_test_with_schema" <<-EOSQL
+		CREATE SCHEMA test_schema;
+		SET search_path TO test_schema,public;
 		CREATE EXTENSION hstore;
 		CREATE EXTENSION postgis;
 		\i /install/script/pgsnapshot_schema_0.6.sql

--- a/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/database/DatabaseConstants.java
+++ b/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/database/DatabaseConstants.java
@@ -68,6 +68,11 @@ public final class DatabaseConstants {
     public static final String TASK_ARG_PROFILE_SQL = "profileSql";
 
     /**
+     * The task argument for specifying a postgresql schema to uses.
+     */
+    public static final String TASK_ARG_POSTGRES_SCHEMA = "postgresSchema";
+
+    /**
      * The default host for a database connection.
      */
     public static final String TASK_DEFAULT_HOST = "localhost";
@@ -111,4 +116,9 @@ public final class DatabaseConstants {
      * The default value for enabling profile on a database connection.
      */
     public static final boolean TASK_DEFAULT_PROFILE_SQL = false;
+
+    /**
+     * The default value for specifying a postgresql schema.
+     */
+    public static final String TASK_DEFAULT_POSTGRES_SCHEMA = "";
 }

--- a/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/database/DatabaseLoginCredentials.java
+++ b/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/database/DatabaseLoginCredentials.java
@@ -16,6 +16,7 @@ public class DatabaseLoginCredentials {
     private boolean forceUtf8;
     private boolean profileSql;
     private DatabaseType dbType;
+    private String postgresSchema;
     
     
 	/**
@@ -58,6 +59,7 @@ public class DatabaseLoginCredentials {
         this.forceUtf8 = forceUtf8;
         this.profileSql = profileSql;
         this.dbType = dbType;
+        this.postgresSchema = "";
     }
     
     
@@ -207,5 +209,23 @@ public class DatabaseLoginCredentials {
 	 */
     public void setDbType(String property) {
         this.dbType = DatabaseType.fromString(property);
+    }
+
+    /**
+     * Returns the postgresql schema.
+     * 
+     * @return The postgresql schema.
+     */
+    public String getPostgresSchema() {
+        return postgresSchema;
+    }
+
+    /**
+     * Updates the postgresql schema.
+     * 
+     * @param postgresSchema The new postgresql schema.
+     */
+    public void setPostgresSchema(String postgresSchema) {
+        this.postgresSchema = postgresSchema;
     }
 }

--- a/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/database/DatabaseTaskManagerFactory.java
+++ b/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/database/DatabaseTaskManagerFactory.java
@@ -55,6 +55,8 @@ public abstract class DatabaseTaskManagerFactory extends TaskManagerFactory {
                 loginCredentials.getProfileSql()));
         loginCredentials.setDbType(getStringArgument(taskConfig, DatabaseConstants.TASK_ARG_DB_TYPE, loginCredentials
 				.getDbType().toString()));
+        loginCredentials.setPostgresSchema(getStringArgument(taskConfig, DatabaseConstants.TASK_ARG_POSTGRES_SCHEMA,
+                loginCredentials.getPostgresSchema().toString()));
 
         return loginCredentials;
     }

--- a/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/common/DatabaseContext.java
+++ b/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/common/DatabaseContext.java
@@ -59,6 +59,13 @@ public class DatabaseContext {
     	jdbcTemplate = new JdbcTemplate(dataSource);
     	
     	setStatementFetchSizeForStreaming();
+
+        if (loginCredentials.getPostgresSchema() != "") {
+            // JJ: should prepend to old search_path
+            jdbcTemplate.execute("SELECT set_config('search_path', '"
+                                 + loginCredentials.getPostgresSchema()
+                                 + ",' || current_setting('search_path'), false)");
+        }
     }
 
 

--- a/osmosis-pgsnapshot/src/test/resources/data/template/v0_6/pgsql_with_schema-authfile.txt
+++ b/osmosis-pgsnapshot/src/test/resources/data/template/v0_6/pgsql_with_schema-authfile.txt
@@ -1,0 +1,4 @@
+host=localhost
+database=pgosmsnap06_test_with_schema
+user=osm
+password=password


### PR DESCRIPTION
Hi,

These two commits add support for a new option postgresSchema on --write-pbf and --truncate-pbf to specify a specific schema to prepend to search_path. The aim of this option is to be able to launch two parallel osmosis processes with a different pbf file to import to a different schema.

A (passing) test was also added to check this new option. I also directly tried the new option with osmosis --read-pbf --write-pgsql.