### PR TITLE
squid:S1192 - String literals should not be duplicated

### DIFF
--- a/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/common/DatabaseContext.java
+++ b/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/common/DatabaseContext.java
@@ -26,6 +26,8 @@ public class DatabaseContext {
 
     private static final Logger LOG = Logger.getLogger(DatabaseContext.class.getName());
 
+    private static final String UNKNOWN_DATABASE_TYPE = "Unknown database type ";
+
     private final DatabaseLoginCredentials loginCredentials;
 
     private Connection connection;
@@ -60,7 +62,7 @@ public class DatabaseContext {
                 identityValueLoader = new MysqlIdentityValueLoader(this);
                 break;
             default:
-                throw new OsmosisRuntimeException("Unknown database type " + loginCredentials.getDbType() + ".");
+                throw new OsmosisRuntimeException(UNKNOWN_DATABASE_TYPE + loginCredentials.getDbType() + ".");
             }
 
         } catch (ClassNotFoundException e) {
@@ -85,7 +87,7 @@ public class DatabaseContext {
                 connection = getMysqlConnection();
                 break;
             default:
-                throw new OsmosisRuntimeException("Unknown database type " + loginCredentials.getDbType() + ".");
+                throw new OsmosisRuntimeException(UNKNOWN_DATABASE_TYPE + loginCredentials.getDbType() + ".");
             }
         }
         
@@ -187,7 +189,7 @@ public class DatabaseContext {
 			}
 			break;
 		default:
-			throw new OsmosisRuntimeException("Unknown database type " + loginCredentials.getDbType() + ".");
+			throw new OsmosisRuntimeException(UNKNOWN_DATABASE_TYPE + loginCredentials.getDbType() + ".");
 		}
 	}
 	
@@ -209,7 +211,7 @@ public class DatabaseContext {
 			}
 			break;
 		default:
-			throw new OsmosisRuntimeException("Unknown database type " + loginCredentials.getDbType() + ".");
+			throw new OsmosisRuntimeException(UNKNOWN_DATABASE_TYPE + loginCredentials.getDbType() + ".");
 		}
 	}
 	
@@ -231,7 +233,7 @@ public class DatabaseContext {
 			}
 			break;
 		default:
-			throw new OsmosisRuntimeException("Unknown database type " + loginCredentials.getDbType() + ".");
+			throw new OsmosisRuntimeException(UNKNOWN_DATABASE_TYPE + loginCredentials.getDbType() + ".");
 		}
 	}
 	
@@ -263,7 +265,7 @@ public class DatabaseContext {
         	executeStatement(statementBuilder.toString());
 			break;
 		default:
-			throw new OsmosisRuntimeException("Unknown database type " + loginCredentials.getDbType() + ".");
+			throw new OsmosisRuntimeException(UNKNOWN_DATABASE_TYPE + loginCredentials.getDbType() + ".");
 		}
 	}
 	
@@ -283,7 +285,7 @@ public class DatabaseContext {
         	executeStatement("UNLOCK TABLES");
 			break;
 		default:
-			throw new OsmosisRuntimeException("Unknown database type " + loginCredentials.getDbType() + ".");
+			throw new OsmosisRuntimeException(UNKNOWN_DATABASE_TYPE + loginCredentials.getDbType() + ".");
 		}
 	}
 
@@ -363,7 +365,7 @@ public class DatabaseContext {
 	        	streamingStatement.setFetchSize(Integer.MIN_VALUE);
 				break;
 			default:
-				throw new OsmosisRuntimeException("Unknown database type " + loginCredentials.getDbType() + ".");
+				throw new OsmosisRuntimeException(UNKNOWN_DATABASE_TYPE + loginCredentials.getDbType() + ".");
 			}
     	} catch (SQLException e) {
     		throw new OsmosisRuntimeException("Unable to update statement fetch size.", e);

--- a/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/common/DatabaseContext2.java
+++ b/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/common/DatabaseContext2.java
@@ -30,6 +30,7 @@ public class DatabaseContext2 {
 
     private static final Logger LOG = Logger.getLogger(DatabaseContext.class.getName());
 
+    private static final String UNKNOWN_DATABASE_TYPE = "Unknown database type ";
     private BasicDataSource dataSource;
     private PlatformTransactionManager txnManager;
     private TransactionTemplate txnTemplate;
@@ -60,7 +61,7 @@ public class DatabaseContext2 {
             identityValueLoader = new MysqlIdentityValueLoader2(this);
             break;
         default:
-            throw new OsmosisRuntimeException("Unknown database type " + loginCredentials.getDbType() + ".");
+            throw new OsmosisRuntimeException(UNKNOWN_DATABASE_TYPE + loginCredentials.getDbType() + ".");
         }
     }
     
@@ -110,7 +111,7 @@ public class DatabaseContext2 {
         	jdbcTemplate.setFetchSize(Integer.MIN_VALUE);
 			break;
 		default:
-			throw new OsmosisRuntimeException("Unknown database type " + dbType + ".");
+			throw new OsmosisRuntimeException(UNKNOWN_DATABASE_TYPE + dbType + ".");
 		}
     }
 	
@@ -144,7 +145,7 @@ public class DatabaseContext2 {
 			}
 			break;
 		default:
-			throw new OsmosisRuntimeException("Unknown database type " + dbType + ".");
+			throw new OsmosisRuntimeException(UNKNOWN_DATABASE_TYPE + dbType + ".");
 		}
 	}
 	
@@ -166,7 +167,7 @@ public class DatabaseContext2 {
 			}
 			break;
 		default:
-			throw new OsmosisRuntimeException("Unknown database type " + dbType + ".");
+			throw new OsmosisRuntimeException(UNKNOWN_DATABASE_TYPE + dbType + ".");
 		}
 	}
 	
@@ -188,7 +189,7 @@ public class DatabaseContext2 {
 			}
 			break;
 		default:
-			throw new OsmosisRuntimeException("Unknown database type " + dbType + ".");
+			throw new OsmosisRuntimeException(UNKNOWN_DATABASE_TYPE + dbType + ".");
 		}
 	}
 	
@@ -220,7 +221,7 @@ public class DatabaseContext2 {
         	jdbcTemplate.update(statementBuilder.toString());
 			break;
 		default:
-			throw new OsmosisRuntimeException("Unknown database type " + dbType + ".");
+			throw new OsmosisRuntimeException(UNKNOWN_DATABASE_TYPE + dbType + ".");
 		}
 	}
 	
@@ -240,7 +241,7 @@ public class DatabaseContext2 {
         	jdbcTemplate.update("UNLOCK TABLES");
 			break;
 		default:
-			throw new OsmosisRuntimeException("Unknown database type " + dbType + ".");
+			throw new OsmosisRuntimeException(UNKNOWN_DATABASE_TYPE + dbType + ".");
 		}
 	}
 

--- a/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/v0_6/ApidbWriter.java
+++ b/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/v0_6/ApidbWriter.java
@@ -54,7 +54,8 @@ public class ApidbWriter implements Sink, EntityProcessor {
 	private static final int INSERT_PRM_COUNT_NODE = 8;
 
     private static final String INSERT_SQL_NODE_TAG_COLUMNS = "INSERT INTO node_tags (node_id, k, v, version)";
-    private static final String INSERT_SQL_NODE_TAG_PARAMS = "?, ?, ?, ?";
+    private static final String QUESTION_MARKS = "?, ?, ?, ?";
+    private static final String INSERT_SQL_NODE_TAG_PARAMS = QUESTION_MARKS;
 	private static final int INSERT_PRM_COUNT_NODE_TAG = 4;
 
     private static final String INSERT_SQL_WAY_COLUMNS =
@@ -63,12 +64,12 @@ public class ApidbWriter implements Sink, EntityProcessor {
 	private static final int INSERT_PRM_COUNT_WAY = 5;
 
     private static final String INSERT_SQL_WAY_TAG_COLUMNS = "INSERT INTO way_tags (way_id, k, v, version)";
-    private static final String INSERT_SQL_WAY_TAG_PARAMS = "?, ?, ?, ?";
+    private static final String INSERT_SQL_WAY_TAG_PARAMS = QUESTION_MARKS;
 	private static final int INSERT_PRM_COUNT_WAY_TAG = 4;
 
     private static final String INSERT_SQL_WAY_NODE_COLUMNS =
     	"INSERT INTO way_nodes (way_id, node_id, sequence_id, version)";
-    private static final String INSERT_SQL_WAY_NODE_PARAMS = "?, ?, ?, ?";
+    private static final String INSERT_SQL_WAY_NODE_PARAMS = QUESTION_MARKS;
 	private static final int INSERT_PRM_COUNT_WAY_NODE = 4;
 
     private static final String INSERT_SQL_RELATION_COLUMNS =
@@ -79,7 +80,7 @@ public class ApidbWriter implements Sink, EntityProcessor {
 
     private static final String INSERT_SQL_RELATION_TAG_COLUMNS =
         "INSERT INTO relation_tags (relation_id, k, v, version)";
-    private static final String INSERT_SQL_RELATION_TAG_PARAMS = "?, ?, ?, ?";
+    private static final String INSERT_SQL_RELATION_TAG_PARAMS = QUESTION_MARKS;
 	private static final int INSERT_PRM_COUNT_RELATION_TAG = 4;
 
     private static final String INSERT_SQL_RELATION_MEMBER_COLUMNS =
@@ -111,17 +112,19 @@ public class ApidbWriter implements Sink, EntityProcessor {
     private static final String LOAD_CURRENT_NODE_TAGS =
     	"INSERT INTO current_node_tags SELECT node_id, k, v FROM node_tags WHERE node_id >= ? AND node_id < ?";
 
+    public static final String WHERE_WAY_ID_AND_WAY_ID = " WHERE way_id >= ? AND way_id < ?";
+
     private static final String LOAD_CURRENT_WAYS =
     	"INSERT INTO current_ways SELECT way_id, changeset_id, timestamp, visible, version FROM ways"
-            + " WHERE way_id >= ? AND way_id < ?";
+            + WHERE_WAY_ID_AND_WAY_ID;
 
     private static final String LOAD_CURRENT_WAY_TAGS =
     	"INSERT INTO current_way_tags SELECT way_id, k, v FROM way_tags"
-            + " WHERE way_id >= ? AND way_id < ?";
+            + WHERE_WAY_ID_AND_WAY_ID;
 
     private static final String LOAD_CURRENT_WAY_NODES =
     	"INSERT INTO current_way_nodes SELECT way_id, node_id, sequence_id FROM way_nodes"
-            + " WHERE way_id >= ? AND way_id < ?";
+            + WHERE_WAY_ID_AND_WAY_ID;
 
     private static final String LOAD_CURRENT_RELATIONS =
     	"INSERT INTO current_relations SELECT relation_id, changeset_id, timestamp, visible, version"
@@ -152,6 +155,7 @@ public class ApidbWriter implements Sink, EntityProcessor {
     private static final int INSERT_BULK_ROW_COUNT_RELATION = 100;
     private static final int INSERT_BULK_ROW_COUNT_RELATION_TAG = 100;
     private static final int INSERT_BULK_ROW_COUNT_RELATION_MEMBER = 100;
+    private static final String DOES_NOT_HAVE_A_TIMESTAMP_SET = " does not have a timestamp set.";
 
     /**
 	 * Builds a multi-row SQL insert statement.
@@ -400,7 +404,7 @@ public class ApidbWriter implements Sink, EntityProcessor {
 
         // We can't write an entity with a null timestamp.
         if (node.getTimestamp() == null) {
-            throw new OsmosisRuntimeException("Node " + node.getId() + " does not have a timestamp set.");
+            throw new OsmosisRuntimeException("Node " + node.getId() + DOES_NOT_HAVE_A_TIMESTAMP_SET);
         }
 
         try {
@@ -432,7 +436,7 @@ public class ApidbWriter implements Sink, EntityProcessor {
 
         // We can't write an entity with a null timestamp.
         if (way.getTimestamp() == null) {
-            throw new OsmosisRuntimeException("Way " + way.getId() + " does not have a timestamp set.");
+            throw new OsmosisRuntimeException("Way " + way.getId() + DOES_NOT_HAVE_A_TIMESTAMP_SET);
         }
 
         try {
@@ -512,7 +516,7 @@ public class ApidbWriter implements Sink, EntityProcessor {
 
         // We can't write an entity with a null timestamp.
         if (relation.getTimestamp() == null) {
-            throw new OsmosisRuntimeException("Relation " + relation.getId() + " does not have a timestamp set.");
+            throw new OsmosisRuntimeException("Relation " + relation.getId() + DOES_NOT_HAVE_A_TIMESTAMP_SET);
         }
 
         try {

--- a/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/v0_6/impl/ChangeWriter.java
+++ b/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/v0_6/impl/ChangeWriter.java
@@ -154,6 +154,10 @@ public class ChangeWriter {
     private static final String DELETE_SQL_RELATION_MEMBER_CURRENT =
     	"DELETE FROM current_relation_members WHERE relation_id = ?";
 
+    private static final String DOES_NOT_HAVE_A_TIMESTAMP_SET = " does not have a timestamp set.";
+    private static final String EXISTS = " exists.";
+    private static final String AND_KEY = " and key=(";
+
     private final DatabaseContext dbCtx;
     private final UserManager userManager;
     private final ChangesetManager changesetManager;
@@ -323,7 +327,7 @@ public class ChangeWriter {
 
         // We can't write an entity with a null timestamp.
         if (node.getTimestamp() == null) {
-            throw new OsmosisRuntimeException("Node " + node.getId() + " does not have a timestamp set.");
+            throw new OsmosisRuntimeException("Node " + node.getId() + DOES_NOT_HAVE_A_TIMESTAMP_SET);
         }
 
         // Add or update the user in the database.
@@ -369,7 +373,7 @@ public class ChangeWriter {
 
         } catch (SQLException e) {
             throw new OsmosisRuntimeException(
-            		"Unable to check if current node with id=" + node.getId() + " exists.", e);
+            		"Unable to check if current node with id=" + node.getId() + EXISTS, e);
         }
         if (exists) {
             // Update the node in the history table.
@@ -428,7 +432,7 @@ public class ChangeWriter {
 
             } catch (SQLException e) {
                 throw new OsmosisRuntimeException("Unable to insert history node tag with id=" + node.getId()
-                        + " and key=(" + tag.getKey() + ").", e);
+                        + AND_KEY + tag.getKey() + ").", e);
             }
         }
 
@@ -450,7 +454,7 @@ public class ChangeWriter {
 
             } catch (SQLException e) {
                 throw new OsmosisRuntimeException("Unable to check if current node with id=" + node.getId()
-                        + " exists.", e);
+                        + EXISTS, e);
             }
             if (exists) {
                 // Update the node in the current table.
@@ -508,7 +512,7 @@ public class ChangeWriter {
 
                 } catch (SQLException e) {
                     throw new OsmosisRuntimeException("Unable to insert current node tag with id=" + node.getId()
-                            + " and key=(" + tag.getKey() + ").", e);
+                            + AND_KEY + tag.getKey() + ").", e);
                 }
             }
         }
@@ -528,7 +532,7 @@ public class ChangeWriter {
 
         // We can't write an entity with a null timestamp.
         if (way.getTimestamp() == null) {
-            throw new OsmosisRuntimeException("Way " + way.getId() + " does not have a timestamp set.");
+            throw new OsmosisRuntimeException("Way " + way.getId() + DOES_NOT_HAVE_A_TIMESTAMP_SET);
         }
 
         // Add or update the user in the database.
@@ -592,7 +596,7 @@ public class ChangeWriter {
             exists = checkIfEntityHistoryExists(selectWayCountStatement, way.getId(), way.getVersion());
 
         } catch (SQLException e) {
-            throw new OsmosisRuntimeException("Unable to check if current way with id=" + way.getId() + " exists.", e);
+            throw new OsmosisRuntimeException("Unable to check if current way with id=" + way.getId() + EXISTS, e);
         }
         if (exists) {
             // Update the way in the history table.
@@ -639,7 +643,7 @@ public class ChangeWriter {
 
             } catch (SQLException e) {
                 throw new OsmosisRuntimeException("Unable to insert history way tag with id=" + way.getId()
-                        + " and key=(" + tag.getKey() + ").", e);
+                        + AND_KEY + tag.getKey() + ").", e);
             }
         }
 
@@ -689,7 +693,7 @@ public class ChangeWriter {
                 exists = checkIfEntityExists(selectWayCurrentCountStatement, way.getId());
 
             } catch (SQLException e) {
-                throw new OsmosisRuntimeException("Unable to check if current way with id=" + way.getId() + " exists.",
+                throw new OsmosisRuntimeException("Unable to check if current way with id=" + way.getId() + EXISTS,
                         e);
             }
             if (exists) {
@@ -736,7 +740,7 @@ public class ChangeWriter {
 
                 } catch (SQLException e) {
                     throw new OsmosisRuntimeException("Unable to insert current way tag with id=" + way.getId()
-                            + " and key=(" + tag.getKey() + ").", e);
+                            + AND_KEY + tag.getKey() + ").", e);
                 }
             }
 
@@ -776,7 +780,7 @@ public class ChangeWriter {
 
         // We can't write an entity with a null timestamp.
         if (relation.getTimestamp() == null) {
-            throw new OsmosisRuntimeException("Relation " + relation.getId() + " does not have a timestamp set.");
+            throw new OsmosisRuntimeException("Relation " + relation.getId() + DOES_NOT_HAVE_A_TIMESTAMP_SET);
         }
 
         // Add or update the user in the database.
@@ -868,7 +872,7 @@ public class ChangeWriter {
 
         } catch (SQLException e) {
             throw new OsmosisRuntimeException("Unable to check if current relation with id=" + relation.getId()
-                    + " exists.", e);
+                    + EXISTS, e);
         }
         if (exists) {
             // Update the relation in the history table.
@@ -917,7 +921,7 @@ public class ChangeWriter {
 
             } catch (SQLException e) {
                 throw new OsmosisRuntimeException("Unable to insert history relation tag with id=" + relation.getId()
-                        + " and key=(" + tag.getKey() + ").", e);
+                        + AND_KEY + tag.getKey() + ").", e);
             }
         }
 
@@ -974,7 +978,7 @@ public class ChangeWriter {
 
             } catch (SQLException e) {
                 throw new OsmosisRuntimeException("Unable to check if current relation with id=" + relation.getId()
-                        + " exists.", e);
+                        + EXISTS, e);
             }
             if (exists) {
                 // Update the relation in the current table.
@@ -1024,7 +1028,7 @@ public class ChangeWriter {
 
                 } catch (SQLException e) {
                     throw new OsmosisRuntimeException("Unable to insert current relation tag with id="
-                            + relation.getId() + " and key=(" + tag.getKey() + ").", e);
+                            + relation.getId() + AND_KEY + tag.getKey() + ").", e);
                 }
             }
 

--- a/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/v0_6/impl/Replicator.java
+++ b/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/v0_6/impl/Replicator.java
@@ -35,6 +35,9 @@ public class Replicator {
 	 */
 	private static final int TRANSACTION_QUERY_SIZE_MAX = 25000;
 
+	private static final String FROM_THE_DATABASE = " from the database.";
+	private static final String LOADED_SYSTEM_TIME = "Loaded system time ";
+
 	private ChangeSink changeSink;
 	private ReplicationSource source;
 	private TransactionManager txnManager;
@@ -307,7 +310,7 @@ public class Replicator {
 			 */
 			systemTimestamp = systemTimeLoader.getSystemTime();
 			if (LOG.isLoggable(Level.FINER)) {
-				LOG.finer("Loaded system time " + systemTimestamp + " from the database.");
+				LOG.finer(LOADED_SYSTEM_TIME + systemTimestamp + FROM_THE_DATABASE);
 			}
 			
 			// Continue onto next step if we've reached the minimum interval or
@@ -336,7 +339,7 @@ public class Replicator {
 			
 			systemTimestamp = systemTimeLoader.getSystemTime();
 			if (LOG.isLoggable(Level.FINER)) {
-				LOG.finer("Loaded system time " + systemTimestamp + " from the database.");
+				LOG.finer(LOADED_SYSTEM_TIME + systemTimestamp + FROM_THE_DATABASE);
 			}
 			
 			// Continue onto next step if we've reached the maximum interval or
@@ -367,7 +370,7 @@ public class Replicator {
 		 */
 		systemTimestamp = systemTimeLoader.getSystemTime();
 		if (LOG.isLoggable(Level.FINER)) {
-			LOG.finer("Loaded system time " + systemTimestamp + " from the database.");
+			LOG.finer(LOADED_SYSTEM_TIME + systemTimestamp + FROM_THE_DATABASE);
 		}
 		
 		// If this is the first interval we are setting an initial state but not

--- a/osmosis-apidb/src/test/java/org/openstreetmap/osmosis/apidb/v0_6/ApiDbTest.java
+++ b/osmosis-apidb/src/test/java/org/openstreetmap/osmosis/apidb/v0_6/ApiDbTest.java
@@ -24,9 +24,19 @@ import org.openstreetmap.osmosis.testutil.AbstractDataTest;
 public class ApiDbTest extends AbstractDataTest {
 
     private static final String DATE_FORMAT = "yyyy-MM-dd_HH:mm:ss";
-	
-	private final DatabaseUtilities dbUtils = new DatabaseUtilities(dataUtils);
-	
+    private static final String V0_6_DB_SNAPSHOT_OSM = "v0_6/db-snapshot.osm";
+    private static final String READ_XML_0_6 = "--read-xml-0.6";
+    private static final String WRITE_APIDB_0_6 = "--write-apidb-0.6";
+    private static final String AUTH_FILE = "authFile=";
+    private static final String ALLOW_INCORRECT_SCHEMA_VERSION_TRUE = "allowIncorrectSchemaVersion=true";
+    private static final String READ_APIDB_0_6 = "--read-apidb-0.6";
+    private static final String TAG_SORT_0_6 = "--tag-sort-0.6";
+    private static final String WRITE_XML_0_6 = "--write-xml-0.6";
+    private static final String V0_6_DB_CHANGESET_OSC = "v0_6/db-changeset.osc";
+    private static final String READ_XML_CHANGE_0_6 = "--read-xml-change-0.6";
+    private static final String WRITE_APIDB_CHANGE_0_6 = "--write-apidb-change-0.6";
+
+    private final DatabaseUtilities dbUtils = new DatabaseUtilities(dataUtils);
 
     private String convertUTCTimeToLocalTime(String dateString) throws ParseException {
         DateFormat inFormat;
@@ -56,7 +66,7 @@ public class ApiDbTest extends AbstractDataTest {
 
         // Generate input files.
         authFile = dbUtils.getAuthorizationFile();
-        inputFile = dataUtils.createDataFile("v0_6/db-snapshot.osm");
+        inputFile = dataUtils.createDataFile(V0_6_DB_SNAPSHOT_OSM);
         outputFile = dataUtils.newFile();
 
         // Remove all existing data from the database.
@@ -64,22 +74,22 @@ public class ApiDbTest extends AbstractDataTest {
 
         // Load the database with a dataset.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-xml-0.6",
-        		inputFile.getPath(),
-        		"--write-apidb-0.6",
-                "authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true"
+                "-q",
+                READ_XML_0_6,
+                inputFile.getPath(),
+                WRITE_APIDB_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE
                 });
 
         // Dump the database to an osm file.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-apidb-0.6",
-        		"authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true",
-        		"--tag-sort-0.6",
-                "--write-xml-0.6",
+                "-q",
+                READ_APIDB_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE,
+                TAG_SORT_0_6,
+                WRITE_XML_0_6,
                 outputFile.getPath()
                 });
 
@@ -101,7 +111,7 @@ public class ApiDbTest extends AbstractDataTest {
 
         // Generate input files.
         authFile = dbUtils.getAuthorizationFile();
-        inputFile = dataUtils.createDataFile("v0_6/db-snapshot.osm");
+        inputFile = dataUtils.createDataFile(V0_6_DB_SNAPSHOT_OSM);
         outputFile = File.createTempFile("test", ".osm");
 
         // Remove all existing data from the database.
@@ -109,21 +119,21 @@ public class ApiDbTest extends AbstractDataTest {
 
         // Load the database with a dataset.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-xml-0.6",
-        		inputFile.getPath(),
-        		"--write-apidb-0.6",
-                "authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true"
+                "-q",
+                READ_XML_0_6,
+                inputFile.getPath(),
+                WRITE_APIDB_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE
                 });
 
         // Dump the database to an osm file.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-apidb-current-0.6",
-        		"authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true",
-                "--tag-sort-0.6", "--write-xml-0.6", outputFile.getPath() });
+                "-q",
+                "--read-apidb-current-0.6",
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE,
+                TAG_SORT_0_6, WRITE_XML_0_6, outputFile.getPath() });
 
         // Validate that the output file matches the input file.
         dataUtils.compareFiles(inputFile, outputFile);
@@ -145,8 +155,8 @@ public class ApiDbTest extends AbstractDataTest {
 
         // Generate input files.
         authFile = dbUtils.getAuthorizationFile();
-        snapshotFile = dataUtils.createDataFile("v0_6/db-snapshot.osm");
-        changesetFile = dataUtils.createDataFile("v0_6/db-changeset.osc");
+        snapshotFile = dataUtils.createDataFile(V0_6_DB_SNAPSHOT_OSM);
+        changesetFile = dataUtils.createDataFile(V0_6_DB_CHANGESET_OSC);
         expectedResultFile = dataUtils.createDataFile("v0_6/db-changeset-expected.osm");
         actualResultFile = File.createTempFile("test", ".osm");
 
@@ -155,30 +165,30 @@ public class ApiDbTest extends AbstractDataTest {
 
         // Load the database with the snapshot file.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-xml-0.6",
-        		snapshotFile.getPath(),
-        		"--write-apidb-0.6",
-                "authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true" });
+                "-q",
+                READ_XML_0_6,
+                snapshotFile.getPath(),
+                WRITE_APIDB_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE});
 
         // Apply the changeset file to the database.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-xml-change-0.6",
-        		changesetFile.getPath(),
-        		"--write-apidb-change-0.6",
-                "authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true" });
+                "-q",
+                READ_XML_CHANGE_0_6,
+                changesetFile.getPath(),
+                WRITE_APIDB_CHANGE_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE});
 
         // Dump the database to an osm file.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-apidb-0.6",
-        		"authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true",
-        		"--tag-sort-0.6",
-                "--write-xml-0.6", actualResultFile.getPath() });
+                "-q",
+                READ_APIDB_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE,
+                TAG_SORT_0_6,
+                WRITE_XML_0_6, actualResultFile.getPath() });
 
         // Validate that the dumped file matches the expected result.
         dataUtils.compareFiles(expectedResultFile, actualResultFile);
@@ -201,8 +211,8 @@ public class ApiDbTest extends AbstractDataTest {
 
         // Generate input files.
         authFile = dbUtils.getAuthorizationFile();
-        snapshotFile = dataUtils.createDataFile("v0_6/db-snapshot.osm");
-        changesetFile = dataUtils.createDataFile("v0_6/db-changeset.osc");
+        snapshotFile = dataUtils.createDataFile(V0_6_DB_SNAPSHOT_OSM);
+        changesetFile = dataUtils.createDataFile(V0_6_DB_CHANGESET_OSC);
         expectedResultFile = dataUtils.createDataFile("v0_6/db-snapshot-b.osm");
         actualResultFile = File.createTempFile("test", ".osm");
 
@@ -211,33 +221,33 @@ public class ApiDbTest extends AbstractDataTest {
 
         // Load the database with the snapshot file.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-xml-0.6",
-        		snapshotFile.getPath(),
-        		"--write-apidb-0.6",
-                "authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true"
+                "-q",
+                READ_XML_0_6,
+                snapshotFile.getPath(),
+                WRITE_APIDB_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE
                 });
 
         // Apply the changeset file to the database.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-xml-change-0.6",
-        		changesetFile.getPath(),
-        		"--write-apidb-change-0.6",
-                "authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true"
+                "-q",
+                READ_XML_CHANGE_0_6,
+                changesetFile.getPath(),
+                WRITE_APIDB_CHANGE_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE
                 });
 
         // Dump the database to an osm file.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-apidb-0.6",
+                "-q",
+                READ_APIDB_0_6,
                 "snapshotInstant=" + convertUTCTimeToLocalTime("2008-01-03_00:00:00"),
-                "authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true",
-                "--tag-sort-0.6",
-                "--write-xml-0.6",
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE,
+                TAG_SORT_0_6,
+                WRITE_XML_0_6,
                 actualResultFile.getPath() });
 
         // Validate that the dumped file matches the expected result.
@@ -261,8 +271,8 @@ public class ApiDbTest extends AbstractDataTest {
 
         // Generate input files.
         authFile = dbUtils.getAuthorizationFile();
-        snapshotFile = dataUtils.createDataFile("v0_6/db-snapshot.osm");
-        changesetFile = dataUtils.createDataFile("v0_6/db-changeset.osc");
+        snapshotFile = dataUtils.createDataFile(V0_6_DB_SNAPSHOT_OSM);
+        changesetFile = dataUtils.createDataFile(V0_6_DB_CHANGESET_OSC);
         expectedResultFile = dataUtils.createDataFile("v0_6/db-changeset-b.osc");
         actualResultFile = File.createTempFile("test", ".osm");
 
@@ -271,32 +281,32 @@ public class ApiDbTest extends AbstractDataTest {
 
         // Load the database with the snapshot file.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-xml-0.6",
-        		snapshotFile.getPath(),
-        		"--write-apidb-0.6",
-                "authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true"
+                "-q",
+                READ_XML_0_6,
+                snapshotFile.getPath(),
+                WRITE_APIDB_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE
                 });
 
         // Apply the changeset file to the database.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-xml-change-0.6",
-        		changesetFile.getPath(),
-        		"--write-apidb-change-0.6",
-                "authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true"
+                "-q",
+                READ_XML_CHANGE_0_6,
+                changesetFile.getPath(),
+                WRITE_APIDB_CHANGE_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE
                 });
 
         // Dump the changeset to an osm file.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-apidb-change-0.6",
+                "-q",
+                "--read-apidb-change-0.6",
                 "intervalBegin=" + convertUTCTimeToLocalTime("2008-01-03_00:00:00"),
                 "intervalEnd=" + convertUTCTimeToLocalTime("2008-01-04_00:00:00"),
-                "authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true",
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE,
                 "--write-xml-change-0.6", actualResultFile.getPath()
                 });
 

--- a/osmosis-apidb/src/test/java/org/openstreetmap/osmosis/apidb/v0_6/ApidbFileReplicatorTest.java
+++ b/osmosis-apidb/src/test/java/org/openstreetmap/osmosis/apidb/v0_6/ApidbFileReplicatorTest.java
@@ -15,6 +15,11 @@ import org.openstreetmap.osmosis.testutil.AbstractDataTest;
  */
 public class ApidbFileReplicatorTest extends AbstractDataTest {
 
+    private static final String REPLICATE_APIDB_0_6 = "--replicate-apidb-0.6";
+    private static final String AUTH_FILE = "authFile=";
+    private static final String ALLOW_INCORRECT_SCHEMA_VERSION_TRUE = "allowIncorrectSchemaVersion=true";
+    private static final String WRITE_REPLICATION = "--write-replication";
+    private static final String WORKING_DIRECTORY = "workingDirectory=";
     private final DatabaseUtilities dbUtils = new DatabaseUtilities(dataUtils);
 
 
@@ -43,81 +48,81 @@ public class ApidbFileReplicatorTest extends AbstractDataTest {
         
         // Initialise replication.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--replicate-apidb-0.6",
-        		"authFile=" + authFile.getPath(),
-                "allowIncorrectSchemaVersion=true",
-        		"--write-replication",
-        		"workingDirectory=" + workingDirectory.getPath()
+                "-q",
+                REPLICATE_APIDB_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE,
+                WRITE_REPLICATION,
+                WORKING_DIRECTORY + workingDirectory.getPath()
                 });
 
         // Load the database with a dataset.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-xml-0.6",
-        		snapshotFile.getPath(),
-        		"--write-apidb-0.6",
-                "authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true"
+                "-q",
+                "--read-xml-0.6",
+                snapshotFile.getPath(),
+                "--write-apidb-0.6",
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE
                 });
         
         // Run replication.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--replicate-apidb-0.6",
-        		"authFile=" + authFile.getPath(),
-                "allowIncorrectSchemaVersion=true",
-        		"--write-replication",
-        		"workingDirectory=" + workingDirectory.getPath()
+                "-q",
+                REPLICATE_APIDB_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE,
+                WRITE_REPLICATION,
+                WORKING_DIRECTORY + workingDirectory.getPath()
                 });
 
         // Apply the changeset file to the database.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-xml-change-0.6",
-        		changesetFile.getPath(),
-        		"--write-apidb-change-0.6",
-                "authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true" });
+                "-q",
+                "--read-xml-change-0.6",
+                changesetFile.getPath(),
+                "--write-apidb-change-0.6",
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE});
         
         // Run replication.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--replicate-apidb-0.6",
-        		"authFile=" + authFile.getPath(),
-                "allowIncorrectSchemaVersion=true",
-        		"--write-replication",
-        		"workingDirectory=" + workingDirectory.getPath()
+                "-q",
+                REPLICATE_APIDB_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE,
+                WRITE_REPLICATION,
+                WORKING_DIRECTORY + workingDirectory.getPath()
                 });
         
         // Ensure that replication runs successfully even if no data is available.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--replicate-apidb-0.6",
-        		"authFile=" + authFile.getPath(),
-                "allowIncorrectSchemaVersion=true",
-        		"--write-replication",
-        		"workingDirectory=" + workingDirectory.getPath()
+                "-q",
+                REPLICATE_APIDB_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE,
+                WRITE_REPLICATION,
+                WORKING_DIRECTORY + workingDirectory.getPath()
                 });
         
         // Ensure that replication can run with multiple loops.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--replicate-apidb-0.6",
-        		"authFile=" + authFile.getPath(),
-                "allowIncorrectSchemaVersion=true",
-        		"iterations=2",
-        		"--write-replication",
-        		"workingDirectory=" + workingDirectory.getPath()
+                "-q",
+                REPLICATE_APIDB_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE,
+                "iterations=2",
+                WRITE_REPLICATION,
+                WORKING_DIRECTORY + workingDirectory.getPath()
                 });
         
         // Decompress the result file.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-xml-change-0.6",
-        		new File(workingDirectory, "000/000/002.osc.gz").getPath(),
-        		"--write-xml-change-0.6",
-        		outputFile.getPath()
+                "-q",
+                "--read-xml-change-0.6",
+                new File(workingDirectory, "000/000/002.osc.gz").getPath(),
+                "--write-xml-change-0.6",
+                outputFile.getPath()
                 });
 
         // Validate that the replicated file matches the input file.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1192 - String literals should not be duplicated.
This pull request removes 324 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
Please let me know if you have any questions.
George Kankava