### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/v0_6/ApidbVersionConstants.java
+++ b/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/v0_6/ApidbVersionConstants.java
@@ -10,12 +10,6 @@ package org.openstreetmap.osmosis.apidb.v0_6;
 public final class ApidbVersionConstants {
 	
 	/**
-	 * This class cannot be instantiated.
-	 */
-	private ApidbVersionConstants() {
-	}
-	
-	/**
 	 * Defines the schema migrations expected to be in the database.
 	 */
 	public static final String[] SCHEMA_MIGRATIONS = {
@@ -24,8 +18,8 @@ public final class ApidbVersionConstants {
 		"21", "22", "23", "24", "25", "26", "27", "28", "29", "30",
 		"31", "32", "33", "34", "35", "36", "37", "38", "39", "40",
 		"41", "42", "43", "44", "45", "46", "47", "48", "49", "50",
-		"51", "52", "53", "54", "55", "56", "57", "20100513171259", 
-		"20100516124737", "20100910084426", "20101114011429", 
+		"51", "52", "53", "54", "55", "56", "57", "20100513171259",
+		"20100516124737", "20100910084426", "20101114011429",
 		"20110322001319", "20110508145337", "20110521142405",
 		"20110925112722", "20111116184519", "20111212183945",
 		"20120123184321", "20120208122334", "20120208194454",
@@ -34,4 +28,10 @@ public final class ApidbVersionConstants {
 		"20121005195010", "20121012044047", "20121119165817",
 		"20121202155309", "20121203124841", "20130328184137"
 	};
+
+	/**
+	 * This class cannot be instantiated.
+	 */
+	private ApidbVersionConstants() {
+	}
 }

--- a/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/v0_6/ApidbWriter.java
+++ b/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/v0_6/ApidbWriter.java
@@ -153,38 +153,6 @@ public class ApidbWriter implements Sink, EntityProcessor {
     private static final int INSERT_BULK_ROW_COUNT_RELATION_TAG = 100;
     private static final int INSERT_BULK_ROW_COUNT_RELATION_MEMBER = 100;
 
-    /**
-	 * Builds a multi-row SQL insert statement.
-	 * 
-	 * @param columnSql
-	 *            The basic query without value bind variables.
-	 * @param parametersSql
-	 *            The SQL parameters portion of the query.
-	 * @param rowCount
-	 *            The number of rows to insert in a single query.
-	 * @return The generated SQL statement.
-	 */
-    private static String buildSqlInsertStatement(String columnSql, String parametersSql, int rowCount) {
-        StringBuilder buffer;
-
-        buffer = new StringBuilder();
-
-        buffer.append(columnSql).append(" VALUES ");
-
-        for (int i = 0; i < rowCount; i++) {
-            if (i > 0) {
-                buffer.append(", ");
-            }
-            
-            buffer.append("(");
-            buffer.append(parametersSql);
-            buffer.append(")");
-        }
-
-        return buffer.toString();
-    }
-
-    
     private String insertSqlSingleNode;
     private String insertSqlBulkNode;
     private String insertSqlSingleNodeTag;
@@ -291,7 +259,37 @@ public class ApidbWriter implements Sink, EntityProcessor {
 
         initialized = false;
     }
-    
+
+    /**
+     * Builds a multi-row SQL insert statement.
+     *
+     * @param columnSql
+     *            The basic query without value bind variables.
+     * @param parametersSql
+     *            The SQL parameters portion of the query.
+     * @param rowCount
+     *            The number of rows to insert in a single query.
+     * @return The generated SQL statement.
+     */
+    private static String buildSqlInsertStatement(String columnSql, String parametersSql, int rowCount) {
+        StringBuilder buffer;
+
+        buffer = new StringBuilder();
+
+        buffer.append(columnSql).append(" VALUES ");
+
+        for (int i = 0; i < rowCount; i++) {
+            if (i > 0) {
+                buffer.append(", ");
+            }
+
+            buffer.append("(");
+            buffer.append(parametersSql);
+            buffer.append(")");
+        }
+
+        return buffer.toString();
+    }
     
     private void buildSqlStatements() {
     	insertSqlSingleNode = buildSqlInsertStatement(INSERT_SQL_NODE_COLUMNS, INSERT_SQL_NODE_PARAMS, 1);

--- a/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/LogLevels.java
+++ b/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/LogLevels.java
@@ -12,13 +12,6 @@ import java.util.logging.Level;
 public final class LogLevels {
 
 	/**
-	 * This class cannot be instantiated.
-	 */
-	private LogLevels() {
-		// Not callable.
-	}
-
-	/**
 	 * This is the default offset into the LOG_LEVELS array.
 	 */
 	public static final int DEFAULT_LEVEL_INDEX = 3;
@@ -27,14 +20,21 @@ public final class LogLevels {
 	 * Defines the log levels supported from the command line.
 	 */
 	public static final Level [] LOG_LEVELS = {
-		Level.OFF,
-		Level.SEVERE,
-		Level.WARNING,
-		Level.INFO,
-		Level.FINE,
-		Level.FINER,
-		Level.FINEST
+			Level.OFF,
+			Level.SEVERE,
+			Level.WARNING,
+			Level.INFO,
+			Level.FINE,
+			Level.FINER,
+			Level.FINEST
 	};
+
+	/**
+	 * This class cannot be instantiated.
+	 */
+	private LogLevels() {
+		// Not callable.
+	}
 
 
 	/**

--- a/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/database/DatabaseConstants.java
+++ b/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/database/DatabaseConstants.java
@@ -8,13 +8,6 @@ package org.openstreetmap.osmosis.core.database;
  * @author Brett Henderson
  */
 public final class DatabaseConstants {
-	
-	/**
-	 * This class cannot be instantiated.
-	 */
-	private DatabaseConstants() {
-	}
-	
 
     /**
      * The task argument for specifying an database authorisation properties file.
@@ -35,7 +28,7 @@ public final class DatabaseConstants {
      * The task argument for specifying the user for a database connection.
      */
     public static final String TASK_ARG_USER = "user";
-    
+
     /**
      * The task argument for specifying the database type to be used.
      */
@@ -121,4 +114,10 @@ public final class DatabaseConstants {
      * The default value for specifying a postgresql schema.
      */
     public static final String TASK_DEFAULT_POSTGRES_SCHEMA = "";
+
+    /**
+     * This class cannot be instantiated.
+     */
+    private DatabaseConstants() {
+    }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
This pull request removes 440 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava