### PR TITLE
squid:S1192 - String literals should not be duplicated

### DIFF
--- a/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/common/DatabaseContext.java
+++ b/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/common/DatabaseContext.java
@@ -60,7 +60,7 @@ public class DatabaseContext implements AutoCloseable {
                 identityValueLoader = new MysqlIdentityValueLoader(this);
                 break;
             default:
-                throw new OsmosisRuntimeException("Unknown database type " + loginCredentials.getDbType() + ".");
+                throwOsmosisRuntimeException();
             }
 
         } catch (ClassNotFoundException e) {
@@ -85,7 +85,7 @@ public class DatabaseContext implements AutoCloseable {
                 connection = getMysqlConnection();
                 break;
             default:
-                throw new OsmosisRuntimeException("Unknown database type " + loginCredentials.getDbType() + ".");
+                throwOsmosisRuntimeException();
             }
         }
         
@@ -187,8 +187,8 @@ public class DatabaseContext implements AutoCloseable {
 			}
 			break;
 		default:
-			throw new OsmosisRuntimeException("Unknown database type " + loginCredentials.getDbType() + ".");
-		}
+            throwOsmosisRuntimeException();
+        }
 	}
 	
 	
@@ -209,8 +209,8 @@ public class DatabaseContext implements AutoCloseable {
 			}
 			break;
 		default:
-			throw new OsmosisRuntimeException("Unknown database type " + loginCredentials.getDbType() + ".");
-		}
+            throwOsmosisRuntimeException();
+        }
 	}
 	
 	
@@ -231,8 +231,8 @@ public class DatabaseContext implements AutoCloseable {
 			}
 			break;
 		default:
-			throw new OsmosisRuntimeException("Unknown database type " + loginCredentials.getDbType() + ".");
-		}
+            throwOsmosisRuntimeException();
+        }
 	}
 	
 	
@@ -263,8 +263,8 @@ public class DatabaseContext implements AutoCloseable {
         	executeStatement(statementBuilder.toString());
 			break;
 		default:
-			throw new OsmosisRuntimeException("Unknown database type " + loginCredentials.getDbType() + ".");
-		}
+            throwOsmosisRuntimeException();
+        }
 	}
 	
 	
@@ -283,8 +283,8 @@ public class DatabaseContext implements AutoCloseable {
         	executeStatement("UNLOCK TABLES");
 			break;
 		default:
-			throw new OsmosisRuntimeException("Unknown database type " + loginCredentials.getDbType() + ".");
-		}
+            throwOsmosisRuntimeException();
+        }
 	}
 
 
@@ -363,13 +363,16 @@ public class DatabaseContext implements AutoCloseable {
 	        	streamingStatement.setFetchSize(Integer.MIN_VALUE);
 				break;
 			default:
-				throw new OsmosisRuntimeException("Unknown database type " + loginCredentials.getDbType() + ".");
-			}
+                throwOsmosisRuntimeException();
+            }
     	} catch (SQLException e) {
     		throw new OsmosisRuntimeException("Unable to update statement fetch size.", e);
     	}
     }
-    
+
+    private void throwOsmosisRuntimeException() {
+        throw new OsmosisRuntimeException("Unknown database type " + loginCredentials.getDbType() + ".");
+    }
 
     /**
 	 * Creates a new database statement that is configured so that any result sets created using it

--- a/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/common/DatabaseContext2.java
+++ b/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/common/DatabaseContext2.java
@@ -30,6 +30,7 @@ public class DatabaseContext2 implements AutoCloseable {
 
     private static final Logger LOG = Logger.getLogger(DatabaseContext.class.getName());
 
+    private static final String UNKNOWN_DATABASE_TYPE = "Unknown database type ";
     private BasicDataSource dataSource;
     private PlatformTransactionManager txnManager;
     private TransactionTemplate txnTemplate;
@@ -60,7 +61,7 @@ public class DatabaseContext2 implements AutoCloseable {
             identityValueLoader = new MysqlIdentityValueLoader2(this);
             break;
         default:
-            throw new OsmosisRuntimeException("Unknown database type " + loginCredentials.getDbType() + ".");
+            throw new OsmosisRuntimeException(UNKNOWN_DATABASE_TYPE + loginCredentials.getDbType() + ".");
         }
     }
     
@@ -110,7 +111,7 @@ public class DatabaseContext2 implements AutoCloseable {
         	jdbcTemplate.setFetchSize(Integer.MIN_VALUE);
 			break;
 		default:
-			throw new OsmosisRuntimeException("Unknown database type " + dbType + ".");
+			throw new OsmosisRuntimeException(UNKNOWN_DATABASE_TYPE + dbType + ".");
 		}
     }
 	
@@ -144,7 +145,7 @@ public class DatabaseContext2 implements AutoCloseable {
 			}
 			break;
 		default:
-			throw new OsmosisRuntimeException("Unknown database type " + dbType + ".");
+			throw new OsmosisRuntimeException(UNKNOWN_DATABASE_TYPE + dbType + ".");
 		}
 	}
 	
@@ -166,7 +167,7 @@ public class DatabaseContext2 implements AutoCloseable {
 			}
 			break;
 		default:
-			throw new OsmosisRuntimeException("Unknown database type " + dbType + ".");
+			throw new OsmosisRuntimeException(UNKNOWN_DATABASE_TYPE + dbType + ".");
 		}
 	}
 	
@@ -188,7 +189,7 @@ public class DatabaseContext2 implements AutoCloseable {
 			}
 			break;
 		default:
-			throw new OsmosisRuntimeException("Unknown database type " + dbType + ".");
+			throw new OsmosisRuntimeException(UNKNOWN_DATABASE_TYPE + dbType + ".");
 		}
 	}
 	
@@ -220,7 +221,7 @@ public class DatabaseContext2 implements AutoCloseable {
         	jdbcTemplate.update(statementBuilder.toString());
 			break;
 		default:
-			throw new OsmosisRuntimeException("Unknown database type " + dbType + ".");
+			throw new OsmosisRuntimeException(UNKNOWN_DATABASE_TYPE + dbType + ".");
 		}
 	}
 	
@@ -240,7 +241,7 @@ public class DatabaseContext2 implements AutoCloseable {
         	jdbcTemplate.update("UNLOCK TABLES");
 			break;
 		default:
-			throw new OsmosisRuntimeException("Unknown database type " + dbType + ".");
+			throw new OsmosisRuntimeException(UNKNOWN_DATABASE_TYPE + dbType + ".");
 		}
 	}
 

--- a/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/v0_6/impl/ChangeWriter.java
+++ b/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/v0_6/impl/ChangeWriter.java
@@ -151,6 +151,10 @@ public class ChangeWriter implements Completable {
     private static final String DELETE_SQL_RELATION_MEMBER_CURRENT =
     	"DELETE FROM current_relation_members WHERE relation_id = ?";
 
+    private static final String DOES_NOT_HAVE_A_TIMESTAMP_SET = " does not have a timestamp set.";
+    private static final String EXISTS = " exists.";
+    private static final String AND_KEY = " and key=(";
+
     private final DatabaseContext dbCtx;
     private final UserManager userManager;
     private final ChangesetManager changesetManager;
@@ -268,7 +272,7 @@ public class ChangeWriter implements Completable {
 
         // We can't write an entity with a null timestamp.
         if (node.getTimestamp() == null) {
-            throw new OsmosisRuntimeException("Node " + node.getId() + " does not have a timestamp set.");
+            throw new OsmosisRuntimeException("Node " + node.getId() + DOES_NOT_HAVE_A_TIMESTAMP_SET);
         }
 
         // Add or update the user in the database.
@@ -314,7 +318,7 @@ public class ChangeWriter implements Completable {
 
         } catch (SQLException e) {
             throw new OsmosisRuntimeException(
-            		"Unable to check if current node with id=" + node.getId() + " exists.", e);
+            		"Unable to check if current node with id=" + node.getId() + EXISTS, e);
         }
         if (exists) {
             // Update the node in the history table.
@@ -373,7 +377,7 @@ public class ChangeWriter implements Completable {
 
             } catch (SQLException e) {
                 throw new OsmosisRuntimeException("Unable to insert history node tag with id=" + node.getId()
-                        + " and key=(" + tag.getKey() + ").", e);
+                        + AND_KEY + tag.getKey() + ").", e);
             }
         }
 
@@ -395,7 +399,7 @@ public class ChangeWriter implements Completable {
 
             } catch (SQLException e) {
                 throw new OsmosisRuntimeException("Unable to check if current node with id=" + node.getId()
-                        + " exists.", e);
+                        + EXISTS, e);
             }
             if (exists) {
                 // Update the node in the current table.
@@ -453,7 +457,7 @@ public class ChangeWriter implements Completable {
 
                 } catch (SQLException e) {
                     throw new OsmosisRuntimeException("Unable to insert current node tag with id=" + node.getId()
-                            + " and key=(" + tag.getKey() + ").", e);
+                            + AND_KEY + tag.getKey() + ").", e);
                 }
             }
         }
@@ -473,7 +477,7 @@ public class ChangeWriter implements Completable {
 
         // We can't write an entity with a null timestamp.
         if (way.getTimestamp() == null) {
-            throw new OsmosisRuntimeException("Way " + way.getId() + " does not have a timestamp set.");
+            throw new OsmosisRuntimeException("Way " + way.getId() + DOES_NOT_HAVE_A_TIMESTAMP_SET);
         }
 
         // Add or update the user in the database.
@@ -537,7 +541,7 @@ public class ChangeWriter implements Completable {
             exists = checkIfEntityHistoryExists(selectWayCountStatement, way.getId(), way.getVersion());
 
         } catch (SQLException e) {
-            throw new OsmosisRuntimeException("Unable to check if current way with id=" + way.getId() + " exists.", e);
+            throw new OsmosisRuntimeException("Unable to check if current way with id=" + way.getId() + EXISTS, e);
         }
         if (exists) {
             // Update the way in the history table.
@@ -584,7 +588,7 @@ public class ChangeWriter implements Completable {
 
             } catch (SQLException e) {
                 throw new OsmosisRuntimeException("Unable to insert history way tag with id=" + way.getId()
-                        + " and key=(" + tag.getKey() + ").", e);
+                        + AND_KEY + tag.getKey() + ").", e);
             }
         }
 
@@ -634,7 +638,7 @@ public class ChangeWriter implements Completable {
                 exists = checkIfEntityExists(selectWayCurrentCountStatement, way.getId());
 
             } catch (SQLException e) {
-                throw new OsmosisRuntimeException("Unable to check if current way with id=" + way.getId() + " exists.",
+                throw new OsmosisRuntimeException("Unable to check if current way with id=" + way.getId() + EXISTS,
                         e);
             }
             if (exists) {
@@ -681,7 +685,7 @@ public class ChangeWriter implements Completable {
 
                 } catch (SQLException e) {
                     throw new OsmosisRuntimeException("Unable to insert current way tag with id=" + way.getId()
-                            + " and key=(" + tag.getKey() + ").", e);
+                            + AND_KEY + tag.getKey() + ").", e);
                 }
             }
 
@@ -721,7 +725,7 @@ public class ChangeWriter implements Completable {
 
         // We can't write an entity with a null timestamp.
         if (relation.getTimestamp() == null) {
-            throw new OsmosisRuntimeException("Relation " + relation.getId() + " does not have a timestamp set.");
+            throw new OsmosisRuntimeException("Relation " + relation.getId() + DOES_NOT_HAVE_A_TIMESTAMP_SET);
         }
 
         // Add or update the user in the database.
@@ -813,7 +817,7 @@ public class ChangeWriter implements Completable {
 
         } catch (SQLException e) {
             throw new OsmosisRuntimeException("Unable to check if current relation with id=" + relation.getId()
-                    + " exists.", e);
+                    + EXISTS, e);
         }
         if (exists) {
             // Update the relation in the history table.
@@ -862,7 +866,7 @@ public class ChangeWriter implements Completable {
 
             } catch (SQLException e) {
                 throw new OsmosisRuntimeException("Unable to insert history relation tag with id=" + relation.getId()
-                        + " and key=(" + tag.getKey() + ").", e);
+                        + AND_KEY + tag.getKey() + ").", e);
             }
         }
 
@@ -919,7 +923,7 @@ public class ChangeWriter implements Completable {
 
             } catch (SQLException e) {
                 throw new OsmosisRuntimeException("Unable to check if current relation with id=" + relation.getId()
-                        + " exists.", e);
+                        + EXISTS, e);
             }
             if (exists) {
                 // Update the relation in the current table.
@@ -969,7 +973,7 @@ public class ChangeWriter implements Completable {
 
                 } catch (SQLException e) {
                     throw new OsmosisRuntimeException("Unable to insert current relation tag with id="
-                            + relation.getId() + " and key=(" + tag.getKey() + ").", e);
+                            + relation.getId() + AND_KEY + tag.getKey() + ").", e);
                 }
             }
 

--- a/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/v0_6/impl/Replicator.java
+++ b/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/v0_6/impl/Replicator.java
@@ -35,6 +35,9 @@ public class Replicator {
 	 */
 	private static final int TRANSACTION_QUERY_SIZE_MAX = 25000;
 
+	private static final String FROM_THE_DATABASE = " from the database.";
+	private static final String LOADED_SYSTEM_TIME = "Loaded system time ";
+
 	private ChangeSink changeSink;
 	private ReplicationSource source;
 	private TransactionManager txnManager;
@@ -305,7 +308,7 @@ public class Replicator {
 			 */
 			systemTimestamp = systemTimeLoader.getSystemTime();
 			if (LOG.isLoggable(Level.FINER)) {
-				LOG.finer("Loaded system time " + systemTimestamp + " from the database.");
+				LOG.finer(LOADED_SYSTEM_TIME + systemTimestamp + FROM_THE_DATABASE);
 			}
 			
 			// Continue onto next step if we've reached the minimum interval or
@@ -334,7 +337,7 @@ public class Replicator {
 			
 			systemTimestamp = systemTimeLoader.getSystemTime();
 			if (LOG.isLoggable(Level.FINER)) {
-				LOG.finer("Loaded system time " + systemTimestamp + " from the database.");
+				LOG.finer(LOADED_SYSTEM_TIME + systemTimestamp + FROM_THE_DATABASE);
 			}
 			
 			// Continue onto next step if we've reached the maximum interval or
@@ -365,7 +368,7 @@ public class Replicator {
 		 */
 		systemTimestamp = systemTimeLoader.getSystemTime();
 		if (LOG.isLoggable(Level.FINER)) {
-			LOG.finer("Loaded system time " + systemTimestamp + " from the database.");
+			LOG.finer(LOADED_SYSTEM_TIME + systemTimestamp + FROM_THE_DATABASE);
 		}
 		
 		// If this is the first interval we are setting an initial state but not

--- a/osmosis-apidb/src/test/java/org/openstreetmap/osmosis/apidb/v0_6/ApiDbTest.java
+++ b/osmosis-apidb/src/test/java/org/openstreetmap/osmosis/apidb/v0_6/ApiDbTest.java
@@ -24,9 +24,19 @@ import org.openstreetmap.osmosis.testutil.AbstractDataTest;
 public class ApiDbTest extends AbstractDataTest {
 
     private static final String DATE_FORMAT = "yyyy-MM-dd_HH:mm:ss";
-	
-	private final DatabaseUtilities dbUtils = new DatabaseUtilities(dataUtils);
-	
+    private static final String V0_6_DB_SNAPSHOT_OSM = "v0_6/db-snapshot.osm";
+    private static final String READ_XML_0_6 = "--read-xml-0.6";
+    private static final String WRITE_APIDB_0_6 = "--write-apidb-0.6";
+    private static final String AUTH_FILE = "authFile=";
+    private static final String ALLOW_INCORRECT_SCHEMA_VERSION_TRUE = "allowIncorrectSchemaVersion=true";
+    private static final String READ_APIDB_0_6 = "--read-apidb-0.6";
+    private static final String TAG_SORT_0_6 = "--tag-sort-0.6";
+    private static final String WRITE_XML_0_6 = "--write-xml-0.6";
+    private static final String V0_6_DB_CHANGESET_OSC = "v0_6/db-changeset.osc";
+    private static final String READ_XML_CHANGE_0_6 = "--read-xml-change-0.6";
+    private static final String WRITE_APIDB_CHANGE_0_6 = "--write-apidb-change-0.6";
+
+    private final DatabaseUtilities dbUtils = new DatabaseUtilities(dataUtils);
 
     private String convertUTCTimeToLocalTime(String dateString) throws ParseException {
         DateFormat inFormat;
@@ -56,7 +66,7 @@ public class ApiDbTest extends AbstractDataTest {
 
         // Generate input files.
         authFile = dbUtils.getAuthorizationFile();
-        inputFile = dataUtils.createDataFile("v0_6/db-snapshot.osm");
+        inputFile = dataUtils.createDataFile(V0_6_DB_SNAPSHOT_OSM);
         outputFile = dataUtils.newFile();
 
         // Remove all existing data from the database.
@@ -64,22 +74,22 @@ public class ApiDbTest extends AbstractDataTest {
 
         // Load the database with a dataset.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-xml-0.6",
-        		inputFile.getPath(),
-        		"--write-apidb-0.6",
-                "authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true"
+                "-q",
+                READ_XML_0_6,
+                inputFile.getPath(),
+                WRITE_APIDB_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE
                 });
 
         // Dump the database to an osm file.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-apidb-0.6",
-        		"authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true",
-        		"--tag-sort-0.6",
-                "--write-xml-0.6",
+                "-q",
+                READ_APIDB_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE,
+                TAG_SORT_0_6,
+                WRITE_XML_0_6,
                 outputFile.getPath()
                 });
 
@@ -101,7 +111,7 @@ public class ApiDbTest extends AbstractDataTest {
 
         // Generate input files.
         authFile = dbUtils.getAuthorizationFile();
-        inputFile = dataUtils.createDataFile("v0_6/db-snapshot.osm");
+        inputFile = dataUtils.createDataFile(V0_6_DB_SNAPSHOT_OSM);
         outputFile = File.createTempFile("test", ".osm");
 
         // Remove all existing data from the database.
@@ -109,21 +119,21 @@ public class ApiDbTest extends AbstractDataTest {
 
         // Load the database with a dataset.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-xml-0.6",
-        		inputFile.getPath(),
-        		"--write-apidb-0.6",
-                "authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true"
+                "-q",
+                READ_XML_0_6,
+                inputFile.getPath(),
+                WRITE_APIDB_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE
                 });
 
         // Dump the database to an osm file.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-apidb-current-0.6",
-        		"authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true",
-                "--tag-sort-0.6", "--write-xml-0.6", outputFile.getPath() });
+                "-q",
+                "--read-apidb-current-0.6",
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE,
+                TAG_SORT_0_6, WRITE_XML_0_6, outputFile.getPath() });
 
         // Validate that the output file matches the input file.
         dataUtils.compareFiles(inputFile, outputFile);
@@ -145,8 +155,8 @@ public class ApiDbTest extends AbstractDataTest {
 
         // Generate input files.
         authFile = dbUtils.getAuthorizationFile();
-        snapshotFile = dataUtils.createDataFile("v0_6/db-snapshot.osm");
-        changesetFile = dataUtils.createDataFile("v0_6/db-changeset.osc");
+        snapshotFile = dataUtils.createDataFile(V0_6_DB_SNAPSHOT_OSM);
+        changesetFile = dataUtils.createDataFile(V0_6_DB_CHANGESET_OSC);
         expectedResultFile = dataUtils.createDataFile("v0_6/db-changeset-expected.osm");
         actualResultFile = File.createTempFile("test", ".osm");
 
@@ -155,30 +165,30 @@ public class ApiDbTest extends AbstractDataTest {
 
         // Load the database with the snapshot file.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-xml-0.6",
-        		snapshotFile.getPath(),
-        		"--write-apidb-0.6",
-                "authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true" });
+                "-q",
+                READ_XML_0_6,
+                snapshotFile.getPath(),
+                WRITE_APIDB_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE});
 
         // Apply the changeset file to the database.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-xml-change-0.6",
-        		changesetFile.getPath(),
-        		"--write-apidb-change-0.6",
-                "authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true" });
+                "-q",
+                READ_XML_CHANGE_0_6,
+                changesetFile.getPath(),
+                WRITE_APIDB_CHANGE_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE});
 
         // Dump the database to an osm file.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-apidb-0.6",
-        		"authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true",
-        		"--tag-sort-0.6",
-                "--write-xml-0.6", actualResultFile.getPath() });
+                "-q",
+                READ_APIDB_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE,
+                TAG_SORT_0_6,
+                WRITE_XML_0_6, actualResultFile.getPath() });
 
         // Validate that the dumped file matches the expected result.
         dataUtils.compareFiles(expectedResultFile, actualResultFile);
@@ -201,8 +211,8 @@ public class ApiDbTest extends AbstractDataTest {
 
         // Generate input files.
         authFile = dbUtils.getAuthorizationFile();
-        snapshotFile = dataUtils.createDataFile("v0_6/db-snapshot.osm");
-        changesetFile = dataUtils.createDataFile("v0_6/db-changeset.osc");
+        snapshotFile = dataUtils.createDataFile(V0_6_DB_SNAPSHOT_OSM);
+        changesetFile = dataUtils.createDataFile(V0_6_DB_CHANGESET_OSC);
         expectedResultFile = dataUtils.createDataFile("v0_6/db-snapshot-b.osm");
         actualResultFile = File.createTempFile("test", ".osm");
 
@@ -211,33 +221,33 @@ public class ApiDbTest extends AbstractDataTest {
 
         // Load the database with the snapshot file.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-xml-0.6",
-        		snapshotFile.getPath(),
-        		"--write-apidb-0.6",
-                "authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true"
+                "-q",
+                READ_XML_0_6,
+                snapshotFile.getPath(),
+                WRITE_APIDB_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE
                 });
 
         // Apply the changeset file to the database.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-xml-change-0.6",
-        		changesetFile.getPath(),
-        		"--write-apidb-change-0.6",
-                "authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true"
+                "-q",
+                READ_XML_CHANGE_0_6,
+                changesetFile.getPath(),
+                WRITE_APIDB_CHANGE_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE
                 });
 
         // Dump the database to an osm file.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-apidb-0.6",
+                "-q",
+                READ_APIDB_0_6,
                 "snapshotInstant=" + convertUTCTimeToLocalTime("2008-01-03_00:00:00"),
-                "authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true",
-                "--tag-sort-0.6",
-                "--write-xml-0.6",
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE,
+                TAG_SORT_0_6,
+                WRITE_XML_0_6,
                 actualResultFile.getPath() });
 
         // Validate that the dumped file matches the expected result.
@@ -261,8 +271,8 @@ public class ApiDbTest extends AbstractDataTest {
 
         // Generate input files.
         authFile = dbUtils.getAuthorizationFile();
-        snapshotFile = dataUtils.createDataFile("v0_6/db-snapshot.osm");
-        changesetFile = dataUtils.createDataFile("v0_6/db-changeset.osc");
+        snapshotFile = dataUtils.createDataFile(V0_6_DB_SNAPSHOT_OSM);
+        changesetFile = dataUtils.createDataFile(V0_6_DB_CHANGESET_OSC);
         expectedResultFile = dataUtils.createDataFile("v0_6/db-changeset-b.osc");
         actualResultFile = File.createTempFile("test", ".osm");
 
@@ -271,32 +281,32 @@ public class ApiDbTest extends AbstractDataTest {
 
         // Load the database with the snapshot file.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-xml-0.6",
-        		snapshotFile.getPath(),
-        		"--write-apidb-0.6",
-                "authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true"
+                "-q",
+                READ_XML_0_6,
+                snapshotFile.getPath(),
+                WRITE_APIDB_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE
                 });
 
         // Apply the changeset file to the database.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-xml-change-0.6",
-        		changesetFile.getPath(),
-        		"--write-apidb-change-0.6",
-                "authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true"
+                "-q",
+                READ_XML_CHANGE_0_6,
+                changesetFile.getPath(),
+                WRITE_APIDB_CHANGE_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE
                 });
 
         // Dump the changeset to an osm file.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-apidb-change-0.6",
+                "-q",
+                "--read-apidb-change-0.6",
                 "intervalBegin=" + convertUTCTimeToLocalTime("2008-01-03_00:00:00"),
                 "intervalEnd=" + convertUTCTimeToLocalTime("2008-01-04_00:00:00"),
-                "authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true",
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE,
                 "--write-xml-change-0.6", actualResultFile.getPath()
                 });
 

--- a/osmosis-apidb/src/test/java/org/openstreetmap/osmosis/apidb/v0_6/ApidbFileReplicatorTest.java
+++ b/osmosis-apidb/src/test/java/org/openstreetmap/osmosis/apidb/v0_6/ApidbFileReplicatorTest.java
@@ -15,6 +15,11 @@ import org.openstreetmap.osmosis.testutil.AbstractDataTest;
  */
 public class ApidbFileReplicatorTest extends AbstractDataTest {
 
+    private static final String REPLICATE_APIDB_0_6 = "--replicate-apidb-0.6";
+    private static final String AUTH_FILE = "authFile=";
+    private static final String ALLOW_INCORRECT_SCHEMA_VERSION_TRUE = "allowIncorrectSchemaVersion=true";
+    private static final String WRITE_REPLICATION = "--write-replication";
+    private static final String WORKING_DIRECTORY = "workingDirectory=";
     private final DatabaseUtilities dbUtils = new DatabaseUtilities(dataUtils);
 
 
@@ -43,81 +48,81 @@ public class ApidbFileReplicatorTest extends AbstractDataTest {
         
         // Initialise replication.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--replicate-apidb-0.6",
-        		"authFile=" + authFile.getPath(),
-                "allowIncorrectSchemaVersion=true",
-        		"--write-replication",
-        		"workingDirectory=" + workingDirectory.getPath()
+                "-q",
+                REPLICATE_APIDB_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE,
+                WRITE_REPLICATION,
+                WORKING_DIRECTORY + workingDirectory.getPath()
                 });
 
         // Load the database with a dataset.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-xml-0.6",
-        		snapshotFile.getPath(),
-        		"--write-apidb-0.6",
-                "authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true"
+                "-q",
+                "--read-xml-0.6",
+                snapshotFile.getPath(),
+                "--write-apidb-0.6",
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE
                 });
         
         // Run replication.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--replicate-apidb-0.6",
-        		"authFile=" + authFile.getPath(),
-                "allowIncorrectSchemaVersion=true",
-        		"--write-replication",
-        		"workingDirectory=" + workingDirectory.getPath()
+                "-q",
+                REPLICATE_APIDB_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE,
+                WRITE_REPLICATION,
+                WORKING_DIRECTORY + workingDirectory.getPath()
                 });
 
         // Apply the changeset file to the database.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-xml-change-0.6",
-        		changesetFile.getPath(),
-        		"--write-apidb-change-0.6",
-                "authFile=" + authFile.getPath(),
-        		"allowIncorrectSchemaVersion=true" });
+                "-q",
+                "--read-xml-change-0.6",
+                changesetFile.getPath(),
+                "--write-apidb-change-0.6",
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE});
         
         // Run replication.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--replicate-apidb-0.6",
-        		"authFile=" + authFile.getPath(),
-                "allowIncorrectSchemaVersion=true",
-        		"--write-replication",
-        		"workingDirectory=" + workingDirectory.getPath()
+                "-q",
+                REPLICATE_APIDB_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE,
+                WRITE_REPLICATION,
+                WORKING_DIRECTORY + workingDirectory.getPath()
                 });
         
         // Ensure that replication runs successfully even if no data is available.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--replicate-apidb-0.6",
-        		"authFile=" + authFile.getPath(),
-                "allowIncorrectSchemaVersion=true",
-        		"--write-replication",
-        		"workingDirectory=" + workingDirectory.getPath()
+                "-q",
+                REPLICATE_APIDB_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE,
+                WRITE_REPLICATION,
+                WORKING_DIRECTORY + workingDirectory.getPath()
                 });
         
         // Ensure that replication can run with multiple loops.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--replicate-apidb-0.6",
-        		"authFile=" + authFile.getPath(),
-                "allowIncorrectSchemaVersion=true",
-        		"iterations=2",
-        		"--write-replication",
-        		"workingDirectory=" + workingDirectory.getPath()
+                "-q",
+                REPLICATE_APIDB_0_6,
+                AUTH_FILE + authFile.getPath(),
+                ALLOW_INCORRECT_SCHEMA_VERSION_TRUE,
+                "iterations=2",
+                WRITE_REPLICATION,
+                WORKING_DIRECTORY + workingDirectory.getPath()
                 });
         
         // Decompress the result file.
         Osmosis.run(new String[] {
-        		"-q",
-        		"--read-xml-change-0.6",
-        		new File(workingDirectory, "000/000/002.osc.gz").getPath(),
-        		"--write-xml-change-0.6",
-        		outputFile.getPath()
+                "-q",
+                "--read-xml-change-0.6",
+                new File(workingDirectory, "000/000/002.osc.gz").getPath(),
+                "--write-xml-change-0.6",
+                outputFile.getPath()
                 });
 
         // Validate that the replicated file matches the input file.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1192 - String literals should not be duplicated.
This pull request removes 324 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
Please let me know if you have any questions.
George Kankava