### PR TITLE
Specify protobuf syntax version.

### DIFF
--- a/osmosis-osm-binary/src/main/protobuf/fileformat.proto
+++ b/osmosis-osm-binary/src/main/protobuf/fileformat.proto
@@ -15,6 +15,8 @@
 
 */
 
+syntax = "proto2";
+
 option optimize_for = LITE_RUNTIME;
 option java_package = "org.openstreetmap.osmosis.osmbinary";
 package OSMPBF;

--- a/osmosis-osm-binary/src/main/protobuf/osmformat.proto
+++ b/osmosis-osm-binary/src/main/protobuf/osmformat.proto
@@ -15,6 +15,8 @@
 
 */
 
+syntax = "proto2";
+
 option optimize_for = LITE_RUNTIME;
 option java_package = "org.openstreetmap.osmosis.osmbinary";
 package OSMPBF;


### PR DESCRIPTION
A small improvement to my earlier PR for protobuf 3.0.0 support (#32).

This fixes warnings with protobuf 3.0.0:
```
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: src/main/protobuf/fileformat.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: src/main/protobuf/osmformat.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
```