### PR TITLE
EntitySorter lets the user chooses to use file compression or not

### DIFF
--- a/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/sort/v0_6/EntitySorter.java
+++ b/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/sort/v0_6/EntitySorter.java
@@ -15,22 +15,34 @@ import org.openstreetmap.osmosis.core.task.v0_6.SinkSource;
 /**
  * A data stream filter that sorts entities. The sort order is specified by
  * comparator provided during instantiation.
- * 
+ *
  * @author Brett Henderson
  */
 public class EntitySorter implements SinkSource {
 	private FileBasedSort<EntityContainer> fileBasedSort;
 	private Sink sink;
-	
-	
+
+
 	/**
 	 * Creates a new instance.
-	 * 
+	 *
 	 * @param comparator
 	 *            The comparator to use for sorting.
 	 */
 	public EntitySorter(Comparator<EntityContainer> comparator) {
-		fileBasedSort = new FileBasedSort<EntityContainer>(new GenericObjectSerializationFactory(), comparator, true);
+		this(comparator, true);
+	}
+
+	/**
+	 * Creates a new instance.
+	 *
+	 * @param comparator
+	 *            The comparator to use for sorting.
+	 * @param useCompression
+	 *            If true, the storage files will be compressed.
+	 */
+	public EntitySorter(Comparator<EntityContainer> comparator, boolean useCompression) {
+		fileBasedSort = new FileBasedSort<EntityContainer>(new GenericObjectSerializationFactory(), comparator, useCompression);
 	}
 
 
@@ -40,24 +52,24 @@ public class EntitySorter implements SinkSource {
 	public void initialize(Map<String, Object> metaData) {
 		sink.initialize(metaData);
 	}
-	
-	
+
+
 	/**
 	 * {@inheritDoc}
 	 */
 	public void process(EntityContainer entityContainer) {
 		fileBasedSort.add(entityContainer);
 	}
-	
-	
+
+
 	/**
 	 * {@inheritDoc}
 	 */
 	public void setSink(Sink sink) {
 		this.sink = sink;
 	}
-	
-	
+
+
 	/**
 	 * {@inheritDoc}
 	 */
@@ -66,12 +78,12 @@ public class EntitySorter implements SinkSource {
 			while (iterator.hasNext()) {
 				sink.process(iterator.next());
 			}
-			
+
 			sink.complete();
 		}
 	}
-	
-	
+
+
 	/**
 	 * {@inheritDoc}
 	 */

--- a/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/sort/v0_6/EntitySorter.java
+++ b/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/sort/v0_6/EntitySorter.java
@@ -42,7 +42,8 @@ public class EntitySorter implements SinkSource {
 	 *            If true, the storage files will be compressed.
 	 */
 	public EntitySorter(Comparator<EntityContainer> comparator, boolean useCompression) {
-		fileBasedSort = new FileBasedSort<EntityContainer>(new GenericObjectSerializationFactory(), comparator, useCompression);
+		fileBasedSort = new FileBasedSort<EntityContainer>(
+			new GenericObjectSerializationFactory(), comparator, useCompression);
 	}
 
 


### PR DESCRIPTION
Hello,

We are using EntitySorter programmatically on small files. We would like to deactivate file compression. 
We observe a x10 in terms of size but a real benefit on computation time.

Before : 2m30 for 150mo
After : 1min30 for 1G

Thanks,
Guillaume