### PR TITLE
Use https instead of http

### DIFF
--- a/osmosis-replication/src/main/resources/org/openstreetmap/osmosis/replication/v0_6/impl/intervalConfiguration.txt
+++ b/osmosis-replication/src/main/resources/org/openstreetmap/osmosis/replication/v0_6/impl/intervalConfiguration.txt
@@ -1,5 +1,5 @@
 # The URL of the directory containing change files.
-baseUrl=http://planet.openstreetmap.org/replication/hour
+baseUrl=https://planet.openstreetmap.org/replication/hour
 
 # The length of an extraction interval in seconds (3600 = 1 hour).
 intervalLength=3600

--- a/osmosis-replication/src/main/resources/org/openstreetmap/osmosis/replication/v0_6/impl/replicationDownloaderConfiguration.txt
+++ b/osmosis-replication/src/main/resources/org/openstreetmap/osmosis/replication/v0_6/impl/replicationDownloaderConfiguration.txt
@@ -1,5 +1,5 @@
 # The URL of the directory containing change files.
-baseUrl=http://planet.openstreetmap.org/replication/minute
+baseUrl=https://planet.openstreetmap.org/replication/minute
 
 # Defines the maximum time interval in seconds to download in a single invocation.
 # Setting to 0 disables this feature.

--- a/osmosis-replication/src/main/resources/org/openstreetmap/osmosis/replication/v0_6/impl/replicationFileMergerConfiguration.txt
+++ b/osmosis-replication/src/main/resources/org/openstreetmap/osmosis/replication/v0_6/impl/replicationFileMergerConfiguration.txt
@@ -1,5 +1,5 @@
 # The URL of the directory containing change files.
-baseUrl=http://planet.openstreetmap.org/replication/minute
+baseUrl=https://planet.openstreetmap.org/replication/minute
 
 # The length of an extraction interval in seconds (3600 = 1 hour).
 intervalLength=60


### PR DESCRIPTION
planet.openstreetmap.org will be changing to https only soon, this PR changes the default replication configurations to use https. 