### PR TITLE
add database commits on apiwrite for every 100000 operations

### DIFF
--- a/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/v0_6/ApidbWriter.java
+++ b/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/v0_6/ApidbWriter.java
@@ -154,6 +154,9 @@ public class ApidbWriter implements Sink, EntityProcessor {
     private static final int INSERT_BULK_ROW_COUNT_RELATION = 100;
     private static final int INSERT_BULK_ROW_COUNT_RELATION_TAG = 100;
     private static final int INSERT_BULK_ROW_COUNT_RELATION_MEMBER = 100;
+    
+    private static final int TRANSACTION_SIZE = 100000;
+    
     private String insertSqlSingleNode;
     private String insertSqlBulkNode;
     private String insertSqlSingleNodeTag;
@@ -190,6 +193,7 @@ public class ApidbWriter implements Sink, EntityProcessor {
     private long minWayId;
     private long maxRelationId;
     private long minRelationId;
+    private long transactionSizeCount;
     private final TileCalculator tileCalculator;
     private final MemberTypeRenderer memberTypeRenderer;
     private boolean initialized;
@@ -254,6 +258,7 @@ public class ApidbWriter implements Sink, EntityProcessor {
         minWayId = Long.MAX_VALUE;
         maxRelationId = Long.MIN_VALUE;
         minRelationId = Long.MAX_VALUE;
+        transactionSizeCount = 0;
 
         tileCalculator = new TileCalculator();
         memberTypeRenderer = new MemberTypeRenderer();
@@ -593,10 +598,16 @@ public class ApidbWriter implements Sink, EntityProcessor {
 
                 populateNodeParameters(bulkNodeStatement, prmIndex, node);
                 prmIndex += INSERT_PRM_COUNT_NODE;
+                transactionSizeCount++;
             }
 
             try {
                 bulkNodeStatement.executeUpdate();
+                
+                if (transactionSizeCount % TRANSACTION_SIZE == 0) {
+                	dbCtx.commit();
+                }
+                
             } catch (SQLException e) {
                 throw new OsmosisRuntimeException("Unable to bulk insert nodes into the database.", e);
             }
@@ -623,6 +634,8 @@ public class ApidbWriter implements Sink, EntityProcessor {
                 addNodeTags(node);
             }
         }
+        
+        dbCtx.commit();
     }
 
     /**
@@ -641,10 +654,15 @@ public class ApidbWriter implements Sink, EntityProcessor {
             for (int i = 0; i < INSERT_BULK_ROW_COUNT_NODE_TAG; i++) {
                 populateEntityTagParameters(bulkNodeTagStatement, prmIndex, nodeTagBuffer.remove(0));
                 prmIndex += INSERT_PRM_COUNT_NODE_TAG;
+                transactionSizeCount++;
             }
 
             try {
                 bulkNodeTagStatement.executeUpdate();
+                
+                if (transactionSizeCount % TRANSACTION_SIZE == 0) {
+                	dbCtx.commit();
+                }
             } catch (SQLException e) {
                 throw new OsmosisRuntimeException("Unable to bulk insert node tags into the database.", e);
             }
@@ -661,6 +679,8 @@ public class ApidbWriter implements Sink, EntityProcessor {
                 }
             }
         }
+        
+        dbCtx.commit();
     }
 
     /**
@@ -687,10 +707,15 @@ public class ApidbWriter implements Sink, EntityProcessor {
 
                 populateWayParameters(bulkWayStatement, prmIndex, way);
                 prmIndex += INSERT_PRM_COUNT_WAY;
+                transactionSizeCount++;
             }
 
             try {
                 bulkWayStatement.executeUpdate();
+                
+                if (transactionSizeCount % TRANSACTION_SIZE == 0) {
+                	dbCtx.commit();
+                }
             } catch (SQLException e) {
                 throw new OsmosisRuntimeException("Unable to bulk insert ways into the database.", e);
             }
@@ -719,6 +744,8 @@ public class ApidbWriter implements Sink, EntityProcessor {
                 addWayNodes(way);
             }
         }
+        
+        dbCtx.commit();
     }
 
     /**
@@ -737,10 +764,15 @@ public class ApidbWriter implements Sink, EntityProcessor {
             for (int i = 0; i < INSERT_BULK_ROW_COUNT_WAY_TAG; i++) {
                 populateEntityTagParameters(bulkWayTagStatement, prmIndex, wayTagBuffer.remove(0));
                 prmIndex += INSERT_PRM_COUNT_WAY_TAG;
+                transactionSizeCount++;
             }
 
             try {
                 bulkWayTagStatement.executeUpdate();
+                
+                if (transactionSizeCount % TRANSACTION_SIZE == 0) {
+                	dbCtx.commit();
+                }
             } catch (SQLException e) {
                 throw new OsmosisRuntimeException("Unable to bulk insert way tags into the database.", e);
             }
@@ -757,6 +789,8 @@ public class ApidbWriter implements Sink, EntityProcessor {
                 }
             }
         }
+        
+        dbCtx.commit();
     }
 
     /**
@@ -775,10 +809,14 @@ public class ApidbWriter implements Sink, EntityProcessor {
             for (int i = 0; i < INSERT_BULK_ROW_COUNT_WAY_NODE; i++) {
                 populateWayNodeParameters(bulkWayNodeStatement, prmIndex, wayNodeBuffer.remove(0));
                 prmIndex += INSERT_PRM_COUNT_WAY_NODE;
+                transactionSizeCount++;
             }
 
             try {
                 bulkWayNodeStatement.executeUpdate();
+                if (transactionSizeCount % TRANSACTION_SIZE == 0) {
+                	dbCtx.commit();
+                }
             } catch (SQLException e) {
                 throw new OsmosisRuntimeException("Unable to bulk insert way nodes into the database.", e);
             }
@@ -795,6 +833,8 @@ public class ApidbWriter implements Sink, EntityProcessor {
                 }
             }
         }
+        
+        dbCtx.commit();
     }
 
     /**
@@ -821,10 +861,14 @@ public class ApidbWriter implements Sink, EntityProcessor {
 
                 populateRelationParameters(bulkRelationStatement, prmIndex, relation);
                 prmIndex += INSERT_PRM_COUNT_RELATION;
+                transactionSizeCount++;
             }
 
             try {
                 bulkRelationStatement.executeUpdate();
+                if (transactionSizeCount % TRANSACTION_SIZE == 0) {
+                	dbCtx.commit();
+                }
             } catch (SQLException e) {
                 throw new OsmosisRuntimeException("Unable to bulk insert relations into the database.", e);
             }
@@ -853,6 +897,8 @@ public class ApidbWriter implements Sink, EntityProcessor {
                 addRelationMembers(relation);
             }
         }
+        
+        dbCtx.commit();
     }
 
     /**
@@ -872,10 +918,14 @@ public class ApidbWriter implements Sink, EntityProcessor {
             for (int i = 0; i < INSERT_BULK_ROW_COUNT_RELATION_TAG; i++) {
                 populateEntityTagParameters(bulkRelationTagStatement, prmIndex, relationTagBuffer.remove(0));
                 prmIndex += INSERT_PRM_COUNT_RELATION_TAG;
+                transactionSizeCount++;
             }
 
             try {
                 bulkRelationTagStatement.executeUpdate();
+                if (transactionSizeCount % TRANSACTION_SIZE == 0) {
+                	dbCtx.commit();
+                }
             } catch (SQLException e) {
                 throw new OsmosisRuntimeException("Unable to bulk insert relation tags into the database.", e);
             }
@@ -892,6 +942,8 @@ public class ApidbWriter implements Sink, EntityProcessor {
                 }
             }
         }
+        
+        dbCtx.commit();
     }
 
     /**
@@ -911,10 +963,14 @@ public class ApidbWriter implements Sink, EntityProcessor {
             for (int i = 0; i < INSERT_BULK_ROW_COUNT_RELATION_MEMBER; i++) {
                 populateRelationMemberParameters(bulkRelationMemberStatement, prmIndex, relationMemberBuffer.remove(0));
                 prmIndex += INSERT_PRM_COUNT_RELATION_MEMBER;
+                transactionSizeCount++;
             }
 
             try {
                 bulkRelationMemberStatement.executeUpdate();
+                if (transactionSizeCount % TRANSACTION_SIZE == 0) {
+                	dbCtx.commit();
+                }
             } catch (SQLException e) {
                 throw new OsmosisRuntimeException("Unable to bulk insert relation members into the database.", e);
             }
@@ -931,6 +987,8 @@ public class ApidbWriter implements Sink, EntityProcessor {
                 }
             }
         }
+        
+        dbCtx.commit();
     }
     
     


### PR DESCRIPTION
this fix is needed for loading large osm files,
since postgresql is limited to 2^32 - 1 operation per transaction
relevant for the issue: [#4597](https://trac.openstreetmap.org/ticket/4597)