### PR TITLE
FIx incorrect update way history sql, on ChangeWriter.java

### DIFF
--- a/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/v0_6/impl/ChangeWriter.java
+++ b/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/v0_6/impl/ChangeWriter.java
@@ -67,7 +67,7 @@ public class ChangeWriter implements Completable {
     	"INSERT INTO ways (way_id, version, timestamp, visible, changeset_id) VALUES (?, ?, ?, ?, ?)";
 
     private static final String UPDATE_SQL_WAY =
-    	"UPDATE current_ways SET timestamp = ?, visible = ?, changeset_id = ? WHERE id = ? AND version = ?";
+    	"UPDATE ways SET timestamp = ?, visible = ?, changeset_id = ? WHERE way_id = ? AND version = ?";
 
     private static final String SELECT_SQL_WAY_COUNT =
     	"SELECT Count(way_id) AS rowCount FROM ways WHERE way_id = ? AND version = ?";


### PR DESCRIPTION
the sql that updates the ways history table (called "ways") was not updated on an existing change (when the change has a way with an existing id and version in the apidb), instead it would update the current ways table (called "current_ways"), with this change, the correct table is updated.