### PR TITLE
Add support for historical information

### DIFF
--- a/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/domain/v0_6/CommonEntityData.java
+++ b/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/domain/v0_6/CommonEntityData.java
@@ -29,7 +29,7 @@ public class CommonEntityData implements Storeable {
 	
 	private long id;
 	private int version;
-	private boolean isVisible;
+	private boolean visible;
 	private int changesetId;
 	private TimestampContainer timestampContainer;
 	private OsmUser user;
@@ -134,7 +134,7 @@ public class CommonEntityData implements Storeable {
 	 *            The unique identifier.
 	 * @param version
 	 *            The version of the entity.
-	 * @param isVisible
+	 * @param visible
 	 * 			  The visible flag, it indicates if entity has been delete. visible=false
 	 * @param timestamp
 	 *            The last updated timestamp.
@@ -143,9 +143,9 @@ public class CommonEntityData implements Storeable {
 	 * @param changesetId
 	 *            The id of the changeset that this version of the entity was created by.
 	 */
-	public CommonEntityData(long id, int version, boolean isVisible, Date timestamp, OsmUser user, long changesetId) {
+	public CommonEntityData(long id, int version, boolean visible, Date timestamp, OsmUser user, long changesetId) {
 		// Chain to the more specific constructor
-		this(id, version, isVisible, new SimpleTimestampContainer(timestamp), user, changesetId);
+		this(id, version, visible, new SimpleTimestampContainer(timestamp), user, changesetId);
 	}
 
 
@@ -156,7 +156,7 @@ public class CommonEntityData implements Storeable {
 	 *            The unique identifier.
 	 * @param version
 	 *            The version of the entity.
-	 * @param isVisible
+	 * @param visible
 	 *            The visible flag, it indicates if entity has been delete. visible=false
 	 * @param timestampContainer
 	 *            The container holding the timestamp in an alternative
@@ -167,8 +167,9 @@ public class CommonEntityData implements Storeable {
 	 *            The id of the changeset that this version of the entity was created by.
 	 */
 	public CommonEntityData(
-			long id, int version, boolean isVisible, TimestampContainer timestampContainer, OsmUser user, long changesetId) {
-		init(id, timestampContainer, user, version, isVisible, changesetId);
+			long id, int version, boolean visible, TimestampContainer timestampContainer, OsmUser user, 
+			long changesetId) {
+		init(id, timestampContainer, user, version, visible, changesetId);
 		tags = new TagCollectionImpl();
 		metaTags = new LazyHashMap<>();
 	}
@@ -181,7 +182,7 @@ public class CommonEntityData implements Storeable {
 	 *            The unique identifier.
 	 * @param version
 	 *            The version of the entity.
-	 * @param isVisible
+	 * @param visible
 	 *            The visible flag, it indicates if entity has been delete. visible=false
 	 * @param timestamp
 	 *            The last updated timestamp.
@@ -193,9 +194,10 @@ public class CommonEntityData implements Storeable {
 	 *            The tags to apply to the object.
 	 */
 	public CommonEntityData(
-			long id, int version, boolean isVisible, Date timestamp, OsmUser user, long changesetId, Collection<Tag> tags) {
+			long id, int version, boolean visible, Date timestamp, OsmUser user, long changesetId, 
+			Collection<Tag> tags) {
 		// Chain to the more specific constructor
-		this(id, version, isVisible, new SimpleTimestampContainer(timestamp), user, changesetId, tags);
+		this(id, version, visible, new SimpleTimestampContainer(timestamp), user, changesetId, tags);
 	}
 
 
@@ -206,7 +208,7 @@ public class CommonEntityData implements Storeable {
 	 *            The unique identifier.
 	 * @param version
 	 *            The version of the entity.
-	 * @param isVisible
+	 * @param visible
 	 *            The visible flag, it indicates if entity has been delete. visible=false
 	 * @param timestampContainer
 	 *            The container holding the timestamp in an alternative
@@ -218,9 +220,9 @@ public class CommonEntityData implements Storeable {
 	 * @param tags
 	 *            The tags to apply to the object.
 	 */
-	public CommonEntityData(long id, int version, boolean isVisible, TimestampContainer timestampContainer, OsmUser user, long changesetId,
-			Collection<Tag> tags) {
-		init(id, timestampContainer, user, version, isVisible, changesetId);
+	public CommonEntityData(long id, int version, boolean visible, TimestampContainer timestampContainer, 
+			OsmUser user, long changesetId, Collection<Tag> tags) {
+		init(id, timestampContainer, user, version, visible, changesetId);
 		this.tags = new TagCollectionImpl(tags);
 		metaTags = new LazyHashMap<String, Object>();
 	}
@@ -237,18 +239,18 @@ public class CommonEntityData implements Storeable {
 	 *            The user that last modified this entity.
 	 * @param newVersion
 	 *            The version of the entity.
-	 * @param newIsVisible
+	 * @param newVisible
 	 *            The visible flag, it indicates if entity has been delete. visible=false
 	 * @param changesetId
 	 *            The id of the changeset that this version of the entity was created by.
 	 */
-	private void init(long newId, TimestampContainer newTimestampContainer, OsmUser newUser, int newVersion, boolean newIsVisible,
-			long newChangesetId) {
+	private void init(long newId, TimestampContainer newTimestampContainer, OsmUser newUser, int newVersion, 
+			boolean newVisible, long newChangesetId) {
 		this.id = newId;
 		this.timestampContainer = newTimestampContainer;
 		this.user = newUser;
 		this.version = newVersion;
-		this.isVisible = newIsVisible;
+		this.visible = newVisible;
 		this.changesetId = LongAsInt.longToInt(newChangesetId);
 	}
 	
@@ -317,7 +319,7 @@ public class CommonEntityData implements Storeable {
 		sw.writeLong(id);
 		
 		sw.writeInteger(version);
-		sw.writeBoolean(isVisible);
+		sw.writeBoolean(visible);
 		
 		if (getTimestamp() != null) {
 			sw.writeBoolean(true);
@@ -430,20 +432,20 @@ public class CommonEntityData implements Storeable {
 	 * @return The visible flag, it indicates if entity has been delete. visible=false.
 	 */
 	public boolean isVisible() {
-		return isVisible;
+		return visible;
 	}
 	
 	
 	/**
 	 * Sets the visible flag.
 	 * 
-	 * @param isVisible
+	 * @param visible
 	 *            The visible flag, it indicates if entity has been delete. visible=false.
 	 */
-	public void isVisible(boolean isVisible) {
+	public void setVisible(boolean visible) {
 		assertWriteable();
 		
-		this.isVisible = isVisible;
+		this.visible = visible;
 	}
 	
 
@@ -630,7 +632,7 @@ public class CommonEntityData implements Storeable {
 	 */
 	public CommonEntityData getWriteableInstance() {
 		if (isReadOnly()) {
-			return new CommonEntityData(id, version, isVisible, timestampContainer, user, changesetId, tags);
+			return new CommonEntityData(id, version, visible, timestampContainer, user, changesetId, tags);
 		} else {
 			return this;
 		}

--- a/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/domain/v0_6/Entity.java
+++ b/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/domain/v0_6/Entity.java
@@ -107,7 +107,7 @@ public abstract class Entity implements Storeable {
 	 */
 	public Entity(long id, int version, TimestampContainer timestampContainer, OsmUser user, long changesetId,
 			Collection<Tag> tags) {
-		entityData = new CommonEntityData(id, version, timestampContainer, user, changesetId, tags);
+		entityData = new CommonEntityData(id, version, true, timestampContainer, user, changesetId, tags);
 	}
 	
 	
@@ -219,6 +219,27 @@ public abstract class Entity implements Storeable {
 	}
 	
 	
+	/**
+	 * Gets the visible flag.
+	 * 
+	 * @return The visible flag, it indicates if entity has been delete. visible=false.
+	 */
+	public boolean isVisible() {
+		return this.entityData.isVisible();
+	}
+
+
+	/**
+	 * Sets the visible flag.
+	 * 
+	 * @param isVisible
+	 *            The visible flag, it indicates if entity has been delete. visible=false.
+	 */
+	public void isVisible(boolean isVisible) {
+		this.entityData.isVisible(isVisible);
+	}
+
+
 	/**
 	 * Gets the timestamp in date form. This is the standard method for
 	 * retrieving timestamp information.

--- a/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/domain/v0_6/Entity.java
+++ b/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/domain/v0_6/Entity.java
@@ -232,11 +232,11 @@ public abstract class Entity implements Storeable {
 	/**
 	 * Sets the visible flag.
 	 * 
-	 * @param isVisible
+	 * @param visible
 	 *            The visible flag, it indicates if entity has been delete. visible=false.
 	 */
-	public void isVisible(boolean isVisible) {
-		this.entityData.isVisible(isVisible);
+	public void isVisible(boolean visible) {
+		this.entityData.setVisible(visible);
 	}
 
 

--- a/osmosis-pbf/src/main/java/crosby/binary/osmosis/OsmosisSerializer.java
+++ b/osmosis-pbf/src/main/java/crosby/binary/osmosis/OsmosisSerializer.java
@@ -28,12 +28,11 @@ import org.openstreetmap.osmosis.core.domain.v0_6.Tag;
 import org.openstreetmap.osmosis.core.domain.v0_6.Way;
 import org.openstreetmap.osmosis.core.domain.v0_6.WayNode;
 import org.openstreetmap.osmosis.core.task.v0_6.Sink;
-
 import org.openstreetmap.osmosis.osmbinary.BinarySerializer;
 import org.openstreetmap.osmosis.osmbinary.Osmformat;
 import org.openstreetmap.osmosis.osmbinary.Osmformat.DenseInfo;
-import org.openstreetmap.osmosis.osmbinary.StringTable;
 import org.openstreetmap.osmosis.osmbinary.Osmformat.Relation.MemberType;
+import org.openstreetmap.osmosis.osmbinary.StringTable;
 import org.openstreetmap.osmosis.osmbinary.file.BlockOutputStream;
 import org.openstreetmap.osmosis.osmbinary.file.FileBlock;
 
@@ -118,9 +117,11 @@ public class OsmosisSerializer extends BinarySerializer implements Sink {
 				int userSid = stable.getIndex(e.getUser().getName());
 				int timestamp = (int) (e.getTimestamp().getTime() / date_granularity);
 				int version = e.getVersion();
+				boolean visible = e.isVisible();
 				long changeset = e.getChangesetId();
 
 				b.addVersion(version);
+				b.addVisible(visible);
 				b.addTimestamp(timestamp - lasttimestamp);
 				lasttimestamp = timestamp;
 				b.addChangeset(changeset - lastchangeset);
@@ -146,6 +147,7 @@ public class OsmosisSerializer extends BinarySerializer implements Sink {
                 }
                 b.setTimestamp((int) (e.getTimestamp().getTime() / date_granularity));
                 b.setVersion(e.getVersion());
+                b.setVisible(e.isVisible());
                 b.setChangeset(e.getChangesetId());
             }
             return b;

--- a/osmosis-pbf2/src/main/java/org/openstreetmap/osmosis/pbf2/v0_6/impl/PbfBlobDecoder.java
+++ b/osmosis-pbf2/src/main/java/org/openstreetmap/osmosis/pbf2/v0_6/impl/PbfBlobDecoder.java
@@ -54,6 +54,7 @@ public class PbfBlobDecoder implements Runnable {
 
 	private static final double COORDINATE_SCALING_FACTOR = 0.000000001;
 	private static final int EMPTY_VERSION = -1;
+	private static final boolean DEFAULT_VISIBLE = true;
 	private static final Date EMPTY_TIMESTAMP = new Date(0);
 	private static final long EMPTY_CHANGESET = -1;
 
@@ -110,7 +111,7 @@ public class PbfBlobDecoder implements Runnable {
 		Osmformat.HeaderBlock header = Osmformat.HeaderBlock.parseFrom(data);
 
 		// Build the list of active and unsupported features in the file.
-		List<String> supportedFeatures = Arrays.asList("OsmSchema-V0.6", "DenseNodes");
+		List<String> supportedFeatures = Arrays.asList("OsmSchema-V0.6", "DenseNodes","HistoricalInformation");
 		List<String> activeFeatures = new ArrayList<String>();
 		List<String> unsupportedFeatures = new ArrayList<String>();
 		for (String feature : header.getRequiredFeaturesList()) {
@@ -177,7 +178,7 @@ public class PbfBlobDecoder implements Runnable {
 			user = OsmUser.NONE;
 		}
 
-		entityData = new CommonEntityData(entityId, info.getVersion(),
+		entityData = new CommonEntityData(entityId, info.getVersion(),info.hasVisible()?info.getVisible():DEFAULT_VISIBLE,
 				fieldDecoder.decodeTimestamp(info.getTimestamp()), user, info.getChangeset());
 
 		buildTags(entityData, keys, values, fieldDecoder);
@@ -190,7 +191,7 @@ public class PbfBlobDecoder implements Runnable {
 			PbfFieldDecoder fieldDecoder) {
 		CommonEntityData entityData;
 
-		entityData = new CommonEntityData(entityId, EMPTY_VERSION, EMPTY_TIMESTAMP, OsmUser.NONE, EMPTY_CHANGESET);
+		entityData = new CommonEntityData(entityId, EMPTY_VERSION, DEFAULT_VISIBLE, EMPTY_TIMESTAMP, OsmUser.NONE, EMPTY_CHANGESET);
 
 		buildTags(entityData, keys, values, fieldDecoder);
 
@@ -271,10 +272,10 @@ public class PbfBlobDecoder implements Runnable {
 					user = OsmUser.NONE;
 				}
 
-				entityData = new CommonEntityData(nodeId, denseInfo.getVersion(i),
+				entityData = new CommonEntityData(nodeId, denseInfo.getVersion(i), (denseInfo.getVisibleCount() > 0)?denseInfo.getVisible(i):DEFAULT_VISIBLE,
 						fieldDecoder.decodeTimestamp(timestamp), user, changesetId);
 			} else {
-				entityData = new CommonEntityData(nodeId, EMPTY_VERSION, EMPTY_TIMESTAMP, OsmUser.NONE,
+				entityData = new CommonEntityData(nodeId, EMPTY_VERSION, DEFAULT_VISIBLE, EMPTY_TIMESTAMP, OsmUser.NONE,
 						EMPTY_CHANGESET);
 			}
 

--- a/osmosis-xml/src/main/java/org/openstreetmap/osmosis/xml/v0_6/impl/EntityWriter.java
+++ b/osmosis-xml/src/main/java/org/openstreetmap/osmosis/xml/v0_6/impl/EntityWriter.java
@@ -37,8 +37,9 @@ public class EntityWriter extends ElementWriter {
 	protected void addCommonAttributes(Entity entity) {
 		addAttribute("id", Long.toString(entity.getId()));
 		addAttribute("version", Integer.toString(entity.getVersion()));
-		if(!entity.isVisible())
+		if (!entity.isVisible()) {
 			addAttribute("visible", Boolean.toString(entity.isVisible()));
+		}
 		addAttribute("timestamp", entity.getFormattedTimestamp(getTimestampFormat()));
 
 		OsmUser user = entity.getUser();

--- a/osmosis-xml/src/main/java/org/openstreetmap/osmosis/xml/v0_6/impl/EntityWriter.java
+++ b/osmosis-xml/src/main/java/org/openstreetmap/osmosis/xml/v0_6/impl/EntityWriter.java
@@ -37,6 +37,8 @@ public class EntityWriter extends ElementWriter {
 	protected void addCommonAttributes(Entity entity) {
 		addAttribute("id", Long.toString(entity.getId()));
 		addAttribute("version", Integer.toString(entity.getVersion()));
+		if(!entity.isVisible())
+			addAttribute("visible", Boolean.toString(entity.isVisible()));
 		addAttribute("timestamp", entity.getFormattedTimestamp(getTimestampFormat()));
 
 		OsmUser user = entity.getUser();

--- a/osmosis-xml/src/main/java/org/openstreetmap/osmosis/xml/v0_6/impl/NodeElementProcessor.java
+++ b/osmosis-xml/src/main/java/org/openstreetmap/osmosis/xml/v0_6/impl/NodeElementProcessor.java
@@ -1,8 +1,7 @@
 // This software is released into the Public Domain.  See copying.txt for details.
 package org.openstreetmap.osmosis.xml.v0_6.impl;
 
-import org.xml.sax.Attributes;
-
+import org.openstreetmap.osmosis.core.OsmosisRuntimeException;
 import org.openstreetmap.osmosis.core.container.v0_6.NodeContainer;
 import org.openstreetmap.osmosis.core.domain.common.TimestampContainer;
 import org.openstreetmap.osmosis.core.domain.v0_6.CommonEntityData;
@@ -12,7 +11,7 @@ import org.openstreetmap.osmosis.core.domain.v0_6.Tag;
 import org.openstreetmap.osmosis.core.task.v0_6.Sink;
 import org.openstreetmap.osmosis.xml.common.BaseElementProcessor;
 import org.openstreetmap.osmosis.xml.common.ElementProcessor;
-import org.openstreetmap.osmosis.core.OsmosisRuntimeException;
+import org.xml.sax.Attributes;
 
 
 /**
@@ -28,6 +27,7 @@ public class NodeElementProcessor extends EntityElementProcessor implements TagL
 	private static final String ATTRIBUTE_NAME_USERID = "uid";
 	private static final String ATTRIBUTE_NAME_CHANGESET_ID = "changeset";
 	private static final String ATTRIBUTE_NAME_VERSION = "version";
+	private static final String ATTRIBUTE_NAME_VISIBLE = "visible";
 	private static final String ATTRIBUTE_NAME_LATITUDE = "lat";
 	private static final String ATTRIBUTE_NAME_LONGITUDE = "lon";
 	
@@ -81,6 +81,8 @@ public class NodeElementProcessor extends EntityElementProcessor implements TagL
 		long id;
 		String sversion;
 		int version;
+		String svisible;
+		boolean visible;
 		TimestampContainer timestampContainer;
 		String rawUserId;
 		String rawUserName;
@@ -97,6 +99,12 @@ public class NodeElementProcessor extends EntityElementProcessor implements TagL
 		} else {
 			version = Integer.parseInt(sversion);
 		}
+		svisible = attributes.getValue(ATTRIBUTE_NAME_VISIBLE);
+		if(svisible == null) {
+			visible = true;
+		}else {
+			visible = Boolean.parseBoolean(svisible);
+		}
 		timestampContainer = createTimestampContainer(attributes.getValue(ATTRIBUTE_NAME_TIMESTAMP));
 		rawUserId = attributes.getValue(ATTRIBUTE_NAME_USERID);
 		rawUserName = attributes.getValue(ATTRIBUTE_NAME_USER);
@@ -107,7 +115,7 @@ public class NodeElementProcessor extends EntityElementProcessor implements TagL
 		
 		user = buildUser(rawUserId, rawUserName);
 		
-		node = new Node(new CommonEntityData(id, version, timestampContainer, user, changesetId), latitude, longitude);
+		node = new Node(new CommonEntityData(id, version, visible, timestampContainer, user, changesetId), latitude, longitude);
 	}
 	
 	/**

--- a/osmosis-xml/src/main/java/org/openstreetmap/osmosis/xml/v0_6/impl/NodeElementProcessor.java
+++ b/osmosis-xml/src/main/java/org/openstreetmap/osmosis/xml/v0_6/impl/NodeElementProcessor.java
@@ -77,6 +77,7 @@ public class NodeElementProcessor extends EntityElementProcessor implements TagL
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public void begin(Attributes attributes) {
 		long id;
 		String sversion;
@@ -100,9 +101,9 @@ public class NodeElementProcessor extends EntityElementProcessor implements TagL
 			version = Integer.parseInt(sversion);
 		}
 		svisible = attributes.getValue(ATTRIBUTE_NAME_VISIBLE);
-		if(svisible == null) {
+		if (svisible == null) {
 			visible = true;
-		}else {
+		} else {
 			visible = Boolean.parseBoolean(svisible);
 		}
 		timestampContainer = createTimestampContainer(attributes.getValue(ATTRIBUTE_NAME_TIMESTAMP));
@@ -115,7 +116,8 @@ public class NodeElementProcessor extends EntityElementProcessor implements TagL
 		
 		user = buildUser(rawUserId, rawUserName);
 		
-		node = new Node(new CommonEntityData(id, version, visible, timestampContainer, user, changesetId), latitude, longitude);
+		node = new Node(new CommonEntityData(id, version, visible, timestampContainer, user, changesetId),
+				latitude, longitude);
 	}
 	
 	/**
@@ -143,6 +145,7 @@ public class NodeElementProcessor extends EntityElementProcessor implements TagL
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public void end() {
 		getSink().process(new NodeContainer(node));
 	}
@@ -155,6 +158,7 @@ public class NodeElementProcessor extends EntityElementProcessor implements TagL
 	 * @param tag
 	 *            The tag to be processed.
 	 */
+	@Override
 	public void processTag(Tag tag) {
 		node.getTags().add(tag);
 	}

--- a/osmosis-xml/src/main/java/org/openstreetmap/osmosis/xml/v0_6/impl/RelationElementProcessor.java
+++ b/osmosis-xml/src/main/java/org/openstreetmap/osmosis/xml/v0_6/impl/RelationElementProcessor.java
@@ -58,6 +58,7 @@ public class RelationElementProcessor extends EntityElementProcessor implements 
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public void begin(Attributes attributes) {
 		long id;
 		String sversion;
@@ -79,9 +80,9 @@ public class RelationElementProcessor extends EntityElementProcessor implements 
 			version = Integer.parseInt(sversion);
 		}
 		svisible = attributes.getValue(ATTRIBUTE_NAME_VISIBLE);
-		if(svisible == null) {
+		if (svisible == null) {
 			visible = true;
-		}else {
+		} else {
 			visible = Boolean.parseBoolean(svisible);
 		}
 		timestampContainer = createTimestampContainer(attributes.getValue(ATTRIBUTE_NAME_TIMESTAMP));
@@ -122,6 +123,7 @@ public class RelationElementProcessor extends EntityElementProcessor implements 
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public void end() {
 		getSink().process(new RelationContainer(relation));
 	}
@@ -134,6 +136,7 @@ public class RelationElementProcessor extends EntityElementProcessor implements 
 	 * @param tag
 	 *            The tag to be processed.
 	 */
+	@Override
 	public void processTag(Tag tag) {
 		relation.getTags().add(tag);
 	}
@@ -146,6 +149,7 @@ public class RelationElementProcessor extends EntityElementProcessor implements 
 	 * @param relationMember
 	 *            The wayNode to be processed.
 	 */
+	@Override
 	public void processRelationMember(RelationMember relationMember) {
 		relation.getMembers().add(relationMember);
 	}

--- a/osmosis-xml/src/main/java/org/openstreetmap/osmosis/xml/v0_6/impl/RelationElementProcessor.java
+++ b/osmosis-xml/src/main/java/org/openstreetmap/osmosis/xml/v0_6/impl/RelationElementProcessor.java
@@ -1,6 +1,7 @@
 // This software is released into the Public Domain.  See copying.txt for details.
 package org.openstreetmap.osmosis.xml.v0_6.impl;
 
+import org.openstreetmap.osmosis.core.OsmosisRuntimeException;
 import org.openstreetmap.osmosis.core.container.v0_6.RelationContainer;
 import org.openstreetmap.osmosis.core.domain.common.TimestampContainer;
 import org.openstreetmap.osmosis.core.domain.v0_6.CommonEntityData;
@@ -12,7 +13,6 @@ import org.openstreetmap.osmosis.core.task.v0_6.Sink;
 import org.openstreetmap.osmosis.xml.common.BaseElementProcessor;
 import org.openstreetmap.osmosis.xml.common.ElementProcessor;
 import org.xml.sax.Attributes;
-import org.openstreetmap.osmosis.core.OsmosisRuntimeException;
 
 
 /**
@@ -29,6 +29,7 @@ public class RelationElementProcessor extends EntityElementProcessor implements 
 	private static final String ATTRIBUTE_NAME_USERID = "uid";
 	private static final String ATTRIBUTE_NAME_CHANGESET_ID = "changeset";
 	private static final String ATTRIBUTE_NAME_VERSION = "version";
+	private static final String ATTRIBUTE_NAME_VISIBLE = "visible";
 	
 	private TagElementProcessor tagElementProcessor;
 	private RelationMemberElementProcessor relationMemberElementProcessor;
@@ -61,6 +62,8 @@ public class RelationElementProcessor extends EntityElementProcessor implements 
 		long id;
 		String sversion;
 		int version;
+		String svisible;
+		boolean visible;
 		TimestampContainer timestampContainer;
 		String rawUserId;
 		String rawUserName;
@@ -75,6 +78,12 @@ public class RelationElementProcessor extends EntityElementProcessor implements 
 		} else {
 			version = Integer.parseInt(sversion);
 		}
+		svisible = attributes.getValue(ATTRIBUTE_NAME_VISIBLE);
+		if(svisible == null) {
+			visible = true;
+		}else {
+			visible = Boolean.parseBoolean(svisible);
+		}
 		timestampContainer = createTimestampContainer(attributes.getValue(ATTRIBUTE_NAME_TIMESTAMP));
 		rawUserId = attributes.getValue(ATTRIBUTE_NAME_USERID);
 		rawUserName = attributes.getValue(ATTRIBUTE_NAME_USER);
@@ -82,7 +91,7 @@ public class RelationElementProcessor extends EntityElementProcessor implements 
 		
 		user = buildUser(rawUserId, rawUserName);
 		
-		relation = new Relation(new CommonEntityData(id, version, timestampContainer, user, changesetId));
+		relation = new Relation(new CommonEntityData(id, version, visible, timestampContainer, user, changesetId));
 	}
 	
 	

--- a/osmosis-xml/src/main/java/org/openstreetmap/osmosis/xml/v0_6/impl/WayElementProcessor.java
+++ b/osmosis-xml/src/main/java/org/openstreetmap/osmosis/xml/v0_6/impl/WayElementProcessor.java
@@ -1,6 +1,7 @@
 // This software is released into the Public Domain.  See copying.txt for details.
 package org.openstreetmap.osmosis.xml.v0_6.impl;
 
+import org.openstreetmap.osmosis.core.OsmosisRuntimeException;
 import org.openstreetmap.osmosis.core.container.v0_6.WayContainer;
 import org.openstreetmap.osmosis.core.domain.common.TimestampContainer;
 import org.openstreetmap.osmosis.core.domain.v0_6.CommonEntityData;
@@ -12,7 +13,6 @@ import org.openstreetmap.osmosis.core.task.v0_6.Sink;
 import org.openstreetmap.osmosis.xml.common.BaseElementProcessor;
 import org.openstreetmap.osmosis.xml.common.ElementProcessor;
 import org.xml.sax.Attributes;
-import org.openstreetmap.osmosis.core.OsmosisRuntimeException;
 
 
 /**
@@ -29,6 +29,7 @@ public class WayElementProcessor extends EntityElementProcessor implements TagLi
 	private static final String ATTRIBUTE_NAME_USERID = "uid";
 	private static final String ATTRIBUTE_NAME_CHANGESET_ID = "changeset";
 	private static final String ATTRIBUTE_NAME_VERSION = "version";
+	private static final String ATTRIBUTE_NAME_VISIBLE = "visible";
 	
 	private TagElementProcessor tagElementProcessor;
 	private WayNodeElementProcessor wayNodeElementProcessor;
@@ -61,6 +62,8 @@ public class WayElementProcessor extends EntityElementProcessor implements TagLi
 		long id;
 		String sversion;
 		int version;
+		String svisible;
+		boolean visible;
 		TimestampContainer timestampContainer;
 		String rawUserId;
 		String rawUserName;
@@ -75,6 +78,12 @@ public class WayElementProcessor extends EntityElementProcessor implements TagLi
 		} else {
 			version = Integer.parseInt(sversion);
 		}
+		svisible = attributes.getValue(ATTRIBUTE_NAME_VISIBLE);
+		if(svisible == null) {
+			visible = true;
+		}else {
+			visible = Boolean.parseBoolean(svisible);
+		}
 		timestampContainer = createTimestampContainer(attributes.getValue(ATTRIBUTE_NAME_TIMESTAMP));
 		rawUserId = attributes.getValue(ATTRIBUTE_NAME_USERID);
 		rawUserName = attributes.getValue(ATTRIBUTE_NAME_USER);
@@ -82,7 +91,7 @@ public class WayElementProcessor extends EntityElementProcessor implements TagLi
 		
 		user = buildUser(rawUserId, rawUserName);
 		
-		way = new Way(new CommonEntityData(id, version, timestampContainer, user, changesetId));
+		way = new Way(new CommonEntityData(id, version, visible, timestampContainer, user, changesetId));
 	}
 	
 	

--- a/osmosis-xml/src/main/java/org/openstreetmap/osmosis/xml/v0_6/impl/WayElementProcessor.java
+++ b/osmosis-xml/src/main/java/org/openstreetmap/osmosis/xml/v0_6/impl/WayElementProcessor.java
@@ -58,6 +58,7 @@ public class WayElementProcessor extends EntityElementProcessor implements TagLi
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public void begin(Attributes attributes) {
 		long id;
 		String sversion;
@@ -79,9 +80,9 @@ public class WayElementProcessor extends EntityElementProcessor implements TagLi
 			version = Integer.parseInt(sversion);
 		}
 		svisible = attributes.getValue(ATTRIBUTE_NAME_VISIBLE);
-		if(svisible == null) {
+		if (svisible == null) {
 			visible = true;
-		}else {
+		} else {
 			visible = Boolean.parseBoolean(svisible);
 		}
 		timestampContainer = createTimestampContainer(attributes.getValue(ATTRIBUTE_NAME_TIMESTAMP));
@@ -122,6 +123,7 @@ public class WayElementProcessor extends EntityElementProcessor implements TagLi
 	/**
 	 * {@inheritDoc}
 	 */
+	@Override
 	public void end() {
 		getSink().process(new WayContainer(way));
 	}
@@ -134,6 +136,7 @@ public class WayElementProcessor extends EntityElementProcessor implements TagLi
 	 * @param tag
 	 *            The tag to be processed.
 	 */
+	@Override
 	public void processTag(Tag tag) {
 		way.getTags().add(tag);
 	}
@@ -146,6 +149,7 @@ public class WayElementProcessor extends EntityElementProcessor implements TagLi
 	 * @param wayNode
 	 *            The wayNode to be processed.
 	 */
+	@Override
 	public void processWayNode(WayNode wayNode) {
 		way.getWayNodes().add(wayNode);
 	}


### PR DESCRIPTION
This pull request add support for historical information and the visible attribute.

It is similar to #37 but incorporates the visible flag into CommonEntityData, as it is part of common data.
The flag is accessible through Entity.isVisible().

The visible flag indicates if this version/change was an deletion or not and is available at least since v0.3.
https://wiki.openstreetmap.org/wiki/API_v0.3.
For working with the osm historical information it is essential to have access to this flag.
