### PR TITLE
Add `port` parameter to --wp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.ipr
 *.iws
 out
+/bin/

--- a/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/common/DataSourceFactory.java
+++ b/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/common/DataSourceFactory.java
@@ -34,12 +34,12 @@ public final class DataSourceFactory {
         switch (credentials.getDbType()) {
         case POSTGRESQL:
         	dataSource.setDriverClassName("org.postgresql.Driver");
-        	dataSource.setUrl("jdbc:postgresql://" + credentials.getHost() + "/" + credentials.getDatabase()
+        	dataSource.setUrl("jdbc:postgresql://" + credentials.getHost() + ":" + credentials.getPort() + "/" + credentials.getDatabase()
         			/*+ "?loglevel=2"*/);
         	break;
         case MYSQL:
         	dataSource.setDriverClassName("com.mysql.jdbc.Driver");
-        	dataSource.setUrl("jdbc:mysql://" + credentials.getHost() + "/" + credentials.getDatabase());
+        	dataSource.setUrl("jdbc:mysql://" + credentials.getHost() + ":" + credentials.getPort() + "/" + credentials.getDatabase());
             break;
         default:
             throw new OsmosisRuntimeException("Unknown database type " + credentials.getDbType() + ".");

--- a/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/common/DatabaseContext.java
+++ b/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/common/DatabaseContext.java
@@ -104,7 +104,8 @@ public class DatabaseContext implements AutoCloseable {
             LOG.finer("Creating a new database connection.");
 
             newConnection = DriverManager.getConnection(
-            		"jdbc:postgresql://" + loginCredentials.getHost() + "/"
+            		"jdbc:postgresql://" + loginCredentials.getHost() + ":"
+            		+ loginCredentials.getPort() + "/"
                     + loginCredentials.getDatabase(), // + "?logLevel=2"
                     loginCredentials.getUser(),
                     loginCredentials.getPassword()
@@ -126,8 +127,10 @@ public class DatabaseContext implements AutoCloseable {
         try {
             String url;
 
-            url = "jdbc:mysql://" + loginCredentials.getHost() + "/" + loginCredentials.getDatabase() + "?user="
-                    + loginCredentials.getUser() + "&password=" + loginCredentials.getPassword();
+            url = "jdbc:mysql://" + loginCredentials.getHost() + ":" + loginCredentials.getPort()
+            		+ "/" + loginCredentials.getDatabase()
+            		+ "?user=" + loginCredentials.getUser()
+                    + "&password=" + loginCredentials.getPassword();
 
             if (loginCredentials.getForceUtf8()) {
                 url += "&useUnicode=true&characterEncoding=UTF-8";

--- a/osmosis-apidb/src/test/java/org/openstreetmap/osmosis/apidb/v0_6/impl/DatabaseUtilities.java
+++ b/osmosis-apidb/src/test/java/org/openstreetmap/osmosis/apidb/v0_6/impl/DatabaseUtilities.java
@@ -44,6 +44,7 @@ public class DatabaseUtilities {
         DatabaseLoginCredentials credentials;
 
         credentials = new DatabaseLoginCredentials(DatabaseConstants.TASK_DEFAULT_HOST,
+        		DatabaseConstants.TASK_DEFAULT_PORT, 
                 DatabaseConstants.TASK_DEFAULT_DATABASE, DatabaseConstants.TASK_DEFAULT_USER,
                 DatabaseConstants.TASK_DEFAULT_PASSWORD, DatabaseConstants.TASK_DEFAULT_FORCE_UTF8,
                 DatabaseConstants.TASK_DEFAULT_PROFILE_SQL, DatabaseConstants.TASK_DEFAULT_DB_TYPE);

--- a/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/database/AuthenticationPropertiesLoader.java
+++ b/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/database/AuthenticationPropertiesLoader.java
@@ -14,6 +14,7 @@ import org.openstreetmap.osmosis.core.OsmosisRuntimeException;
  * The recognised properties are:
  * <ul>
  * <li>host</li>
+ * <li>port</li>
  * <li>database</li>
  * <li>user</li>
  * <li>password</li>
@@ -25,6 +26,7 @@ import org.openstreetmap.osmosis.core.OsmosisRuntimeException;
 public class AuthenticationPropertiesLoader {
 
     private static final String KEY_HOST = "host";
+    private static final String KEY_PORT = "port";
     private static final String KEY_DATABASE = "database";
     private static final String KEY_USER = "user";
     private static final String KEY_PASSWORD = "password";
@@ -68,6 +70,9 @@ public class AuthenticationPropertiesLoader {
 
         if (properties.containsKey(KEY_HOST)) {
             loginCredentials.setHost(properties.getProperty(KEY_HOST));
+        }
+        if (properties.containsKey(KEY_PORT)) {
+            loginCredentials.setPort(properties.getProperty(KEY_PORT));
         }
         if (properties.containsKey(KEY_DATABASE)) {
             loginCredentials.setDatabase(properties.getProperty(KEY_DATABASE));

--- a/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/database/DatabaseConstants.java
+++ b/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/database/DatabaseConstants.java
@@ -20,6 +20,11 @@ public final class DatabaseConstants {
     public static final String TASK_ARG_HOST = "host";
 
     /**
+     * The task argument for specifying the port for a database connection.
+     */
+    public static final String TASK_ARG_PORT = "port";
+    
+    /**
      * The task argument for specifying the database instance for a database connection.
      */
     public static final String TASK_ARG_DATABASE = "database";
@@ -70,6 +75,11 @@ public final class DatabaseConstants {
      */
     public static final String TASK_DEFAULT_HOST = "localhost";
 
+    /**
+     * The default port for a database connection.
+     */
+    public static final String TASK_DEFAULT_PORT = "5432";
+    
     /**
      * The default database for a database connection.
      */

--- a/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/database/DatabaseLoginCredentials.java
+++ b/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/database/DatabaseLoginCredentials.java
@@ -10,6 +10,7 @@ public class DatabaseLoginCredentials {
 
 	private String datasourceJndiLocation;
     private String host;
+    private String port;
     private String database;
     private String user;
     private String password;
@@ -35,6 +36,8 @@ public class DatabaseLoginCredentials {
 	 * 
 	 * @param host
 	 *            The server hosting the database.
+	 * @param port
+	 *            The port the database is running on. Defaults to 5432.
 	 * @param database
 	 *            The database instance.
 	 * @param user
@@ -50,9 +53,10 @@ public class DatabaseLoginCredentials {
 	 * @param dbType
 	 *            The database type.
 	 */
-    public DatabaseLoginCredentials(String host, String database, String user, String password, boolean forceUtf8,
+    public DatabaseLoginCredentials(String host, String port, String database, String user, String password, boolean forceUtf8,
             boolean profileSql, DatabaseType dbType) {
         this.host = host;
+        this.port = port;
         this.database = database;
         this.user = user;
         this.password = password;
@@ -61,7 +65,7 @@ public class DatabaseLoginCredentials {
         this.dbType = dbType;
         this.postgresSchema = "";
     }
-    
+
     
 	/**
 	 * Gets the location of the datasource in JNDI. If null, new connections
@@ -82,7 +86,8 @@ public class DatabaseLoginCredentials {
     public String getHost() {
         return host;
     }
-
+    
+    
     /**
      * Updates the host.
      * 
@@ -90,6 +95,24 @@ public class DatabaseLoginCredentials {
      */
     public void setHost(String host) {
         this.host = host;
+    }
+
+    /**
+     * Returns the port.
+     * 
+     * @return The port.
+     */
+    public String getPort() {
+        return port;
+    }
+
+    /**
+     * Updates the port.
+     * 
+     * @param port The new port.
+     */
+    public void setPort(String port) {
+        this.port = port;
     }
 
     /**

--- a/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/database/DatabaseTaskManagerFactory.java
+++ b/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/database/DatabaseTaskManagerFactory.java
@@ -24,6 +24,7 @@ public abstract class DatabaseTaskManagerFactory extends TaskManagerFactory {
 
         // Create a new credential object with default values.
         loginCredentials = new DatabaseLoginCredentials(DatabaseConstants.TASK_DEFAULT_HOST,
+        		DatabaseConstants.TASK_DEFAULT_PORT,
                 DatabaseConstants.TASK_DEFAULT_DATABASE, DatabaseConstants.TASK_DEFAULT_USER,
                 DatabaseConstants.TASK_DEFAULT_PASSWORD, DatabaseConstants.TASK_DEFAULT_FORCE_UTF8,
                 DatabaseConstants.TASK_DEFAULT_PROFILE_SQL, DatabaseConstants.TASK_DEFAULT_DB_TYPE);
@@ -43,6 +44,8 @@ public abstract class DatabaseTaskManagerFactory extends TaskManagerFactory {
         // command line.
         loginCredentials.setHost(getStringArgument(taskConfig, DatabaseConstants.TASK_ARG_HOST, loginCredentials
                 .getHost()));
+        loginCredentials.setPort(getStringArgument(taskConfig, DatabaseConstants.TASK_ARG_PORT, loginCredentials
+                .getPort()));
         loginCredentials.setDatabase(getStringArgument(taskConfig, DatabaseConstants.TASK_ARG_DATABASE,
                 loginCredentials.getDatabase()));
         loginCredentials.setUser(getStringArgument(taskConfig, DatabaseConstants.TASK_ARG_USER, loginCredentials

--- a/osmosis-extract/src/main/java/org/openstreetmap/osmosis/extract/apidb/common/Configuration.java
+++ b/osmosis-extract/src/main/java/org/openstreetmap/osmosis/extract/apidb/common/Configuration.java
@@ -20,6 +20,7 @@ import org.openstreetmap.osmosis.core.database.DatabaseType;
 public class Configuration {
 
 	private static final String KEY_HOST = "host";
+	private static final String KEY_PORT = "port";
 	private static final String KEY_DATABASE = "database";
 	private static final String KEY_USER = "user";
 	private static final String KEY_PASSWORD = "password";
@@ -80,6 +81,15 @@ public class Configuration {
 	 */
 	public String getHost() {
 		return getProperty(KEY_HOST);
+	}
+
+	/**
+	 * Returns the database port.
+	 * 
+	 * @return The database port.
+	 */
+	public String getPort() {
+		return getProperty(KEY_PORT);
 	}
 
 
@@ -201,7 +211,7 @@ public class Configuration {
 	 * @return The database login credentials.
 	 */
 	public DatabaseLoginCredentials getDatabaseLoginCredentials() {
-		return new DatabaseLoginCredentials(getHost(), getDatabase(), getUser(), getPassword(), false, false,
+		return new DatabaseLoginCredentials(getHost(), getPort(), getDatabase(), getUser(), getPassword(), false, false,
 				getDbType());
 	}
 	

--- a/osmosis-extract/src/main/java/org/openstreetmap/osmosis/extract/apidb/v0_6/OsmosisExtractApiDb.java
+++ b/osmosis-extract/src/main/java/org/openstreetmap/osmosis/extract/apidb/v0_6/OsmosisExtractApiDb.java
@@ -234,6 +234,7 @@ public class OsmosisExtractApiDb {
 
 		System.out.println("Configuration");
 		System.out.println("\thost: " + configuration.getHost());
+		System.out.println("\tport: " + configuration.getPort());
 		System.out.println("\tdatabase: " + configuration.getDatabase());
 		System.out.println("\tuser: " + configuration.getUser());
 		System.out.println("\tpassword: " + configuration.getPassword());

--- a/osmosis-extract/src/main/resources/org/openstreetmap/osmosis/extract/apidb/v0_6/osmosis-extract-apidb.conf
+++ b/osmosis-extract/src/main/resources/org/openstreetmap/osmosis/extract/apidb/v0_6/osmosis-extract-apidb.conf
@@ -1,5 +1,7 @@
 # The database host system.
 host=localhost
+# The database port.
+port=5432
 # The database instance.
 database=osm
 # The database user.

--- a/osmosis-extract/src/test/java/org/openstreetmap/osmosis/extract/apidb/v0_6/DatabaseUtilities.java
+++ b/osmosis-extract/src/test/java/org/openstreetmap/osmosis/extract/apidb/v0_6/DatabaseUtilities.java
@@ -43,7 +43,7 @@ public class DatabaseUtilities {
         AuthenticationPropertiesLoader credentialsLoader;
         DatabaseLoginCredentials credentials;
 
-        credentials = new DatabaseLoginCredentials(DatabaseConstants.TASK_DEFAULT_HOST,
+        credentials = new DatabaseLoginCredentials(DatabaseConstants.TASK_DEFAULT_HOST, DatabaseConstants.TASK_DEFAULT_PORT, 
                 DatabaseConstants.TASK_DEFAULT_DATABASE, DatabaseConstants.TASK_DEFAULT_USER,
                 DatabaseConstants.TASK_DEFAULT_PASSWORD, DatabaseConstants.TASK_DEFAULT_FORCE_UTF8,
                 DatabaseConstants.TASK_DEFAULT_PROFILE_SQL, DatabaseConstants.TASK_DEFAULT_DB_TYPE);

--- a/osmosis-pgsimple/src/main/java/org/openstreetmap/osmosis/pgsimple/common/DatabaseContext.java
+++ b/osmosis-pgsimple/src/main/java/org/openstreetmap/osmosis/pgsimple/common/DatabaseContext.java
@@ -62,7 +62,7 @@ public class DatabaseContext implements AutoCloseable {
 	private Connection getConnectionFromDriverManager() {
 		try {
 			return DriverManager.getConnection(
-				"jdbc:postgresql://" + loginCredentials.getHost() + "/"
+				"jdbc:postgresql://" + loginCredentials.getHost() + ":" + loginCredentials.getPort() + "/"
 				+ loginCredentials.getDatabase(),
 		    	// + "?logLevel=2"
 		    	loginCredentials.getUser(),

--- a/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/common/DataSourceManager.java
+++ b/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/common/DataSourceManager.java
@@ -47,7 +47,7 @@ public final class DataSourceManager implements Closeable {
 		localDataSource = new BasicDataSource();
 		
 		localDataSource.setDriverClassName("org.postgresql.Driver");
-		localDataSource.setUrl("jdbc:postgresql://" + credentials.getHost() + "/" + credentials.getDatabase()
+		localDataSource.setUrl("jdbc:postgresql://" + credentials.getHost() + ":" + credentials.getPort() + "/" + credentials.getDatabase()
     			/*+ "?loglevel=2"*/);
         
 		localDataSource.setUsername(credentials.getUser());
@@ -87,7 +87,7 @@ public final class DataSourceManager implements Closeable {
 			}
 			
 			return DriverManager.getConnection(
-				"jdbc:postgresql://" + credentials.getHost() + "/"
+				"jdbc:postgresql://" + credentials.getHost() + ":" + credentials.getPort() + "/"
 				+ credentials.getDatabase(),
 		    	// + "?logLevel=2"
 				credentials.getUser(),

--- a/package/bin/osmosis
+++ b/package/bin/osmosis
@@ -45,11 +45,11 @@ Example Usage
 
 Import a planet file into a local PostgreSQL database.
 
-osmosis --read-xml file=~/osm/planbet/planet.osm --write-apidb host="x" database="x" user="x" password="x"
+osmosis --read-xml file=~/osm/planbet/planet.osm --write-apidb host="x" port="x" database="x" user="x" password="x"
 
 Export a planet file from a local PostgreSQL database.
 
-osmosis --read-apidb host="x" database="x" user="x" password="x" --write-xml file="planet.osm"
+osmosis --read-apidb host="x" port="x" database="x" user="x" password="x" --write-xml file="planet.osm"
 
 Derive a change set between two planet files.
 
@@ -57,7 +57,7 @@ osmosis --read-xml file="planet2.osm" --read-xml file="planet1.osm" --derive-cha
 
 Derive a change set between a planet file and a database.
 
-osmosis --read-mysql host="x" database="x" user="x" password="x" --read-xml file="planet1.osm" --derive-change --write-xml-change file="planetdiff-1-2.osc"
+osmosis --read-mysql host="x" port="x" database="x" user="x" password="x" --read-xml file="planet1.osm" --derive-change --write-xml-change file="planetdiff-1-2.osc"
 
 Apply a change set to a planet file.
 


### PR DESCRIPTION
This PR adds a `port` parameter to set the port the PostgreSQL database is running at so you can do

`osmosis --rb planet/utah-latest.osm.pbf --wp database=osm port=5433 user=osm`

This is convenient if you have multiple PostgreSQL instances running side by side or you are running the PostgreSQL server on some non-standard port for other reasons.

I did try `host=localhost:5433` but that didn't work and also didn't seem like a very clean solution given that `psql` for example uses a separate parameter for it as well.