### PR TITLE
Add match by osm entity ID

### DIFF
--- a/osmosis-tagtransform/src/main/java/org/openstreetmap/osmosis/tagtransform/Matcher.java
+++ b/osmosis-tagtransform/src/main/java/org/openstreetmap/osmosis/tagtransform/Matcher.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 public interface Matcher {
 
-	Collection<Match> match(Map<String, String> tags, TTEntityType type, String uname, int uid);
+	Collection<Match> match(long id, Map<String, String> tags, TTEntityType type, String uname, int uid);
 
 
 	void outputStats(StringBuilder output, String indent);

--- a/osmosis-tagtransform/src/main/java/org/openstreetmap/osmosis/tagtransform/Translation.java
+++ b/osmosis-tagtransform/src/main/java/org/openstreetmap/osmosis/tagtransform/Translation.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 public interface Translation {
 
-	Collection<Match> match(Map<String, String> tags, TTEntityType entityType, String uname, int uid);
+	Collection<Match> match(long id, Map<String, String> tags, TTEntityType entityType, String uname, int uid);
 
 
 	boolean isDropOnMatch();

--- a/osmosis-tagtransform/src/main/java/org/openstreetmap/osmosis/tagtransform/impl/AndMatcher.java
+++ b/osmosis-tagtransform/src/main/java/org/openstreetmap/osmosis/tagtransform/impl/AndMatcher.java
@@ -29,8 +29,8 @@ public class AndMatcher implements Matcher {
 
 
 	@Override
-	public Collection<Match> match(Map<String, String> tags, TTEntityType entityType, String entityUname,
-			int entityUid) {
+	public Collection<Match> match(long entityId, Map<String, String> tags, TTEntityType entityType, String entityUname,
+                                   int entityUid) {
 		if (this.type != null && this.type != entityType) {
 			return null;
 		}
@@ -43,7 +43,7 @@ public class AndMatcher implements Matcher {
 
 		List<Match> allMatches = new ArrayList<Match>();
 		for (Matcher matcher : matchers) {
-			Collection<Match> matches = matcher.match(tags, entityType, entityUname, entityUid);
+			Collection<Match> matches = matcher.match(entityId, tags, entityType, entityUname, entityUid);
 			if (matches == null || matches.isEmpty()) {
 				return null;
 			}

--- a/osmosis-tagtransform/src/main/java/org/openstreetmap/osmosis/tagtransform/impl/IdMatcher.java
+++ b/osmosis-tagtransform/src/main/java/org/openstreetmap/osmosis/tagtransform/impl/IdMatcher.java
@@ -1,41 +1,27 @@
 // This software is released into the Public Domain.  See copying.txt for details.
 package org.openstreetmap.osmosis.tagtransform.impl;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.regex.Pattern;
-
 import org.openstreetmap.osmosis.tagtransform.Match;
 import org.openstreetmap.osmosis.tagtransform.Matcher;
 import org.openstreetmap.osmosis.tagtransform.TTEntityType;
 
+import java.util.*;
 
-public class NoTagMatcher implements Matcher {
 
-	private Pattern keyPattern;
-	private Pattern valuePattern;
+public class IdMatcher implements Matcher {
+
+	private Set<Long> ids;
 	private long matchHits;
 
-
-	public NoTagMatcher(String keyPattern, String valuePattern) {
-		this.keyPattern = Pattern.compile(keyPattern);
-		this.valuePattern = Pattern.compile(valuePattern);
+	IdMatcher(Set<Long> ids) {
+		this.ids = ids;
 	}
-
 
 	@Override
 	public Collection<Match> match(long id, Map<String, String> tags, TTEntityType type, String uname, int uid) {
-		// loop through the tags to find matches
-		for (Entry<String, String> tag : tags.entrySet()) {
-			java.util.regex.Matcher keyMatch = keyPattern.matcher(tag.getKey());
-			java.util.regex.Matcher valueMatch = valuePattern.matcher(tag.getValue());
-			if (keyMatch.matches() && valueMatch.matches()) {
-				return null;
-			}
+		if (!ids.contains(id))  {
+			return null;
 		}
-
 		matchHits += 1;
 		return Collections.singleton(NULL_MATCH);
 	}
@@ -44,10 +30,18 @@ public class NoTagMatcher implements Matcher {
 	@Override
 	public void outputStats(StringBuilder output, String indent) {
 		output.append(indent);
-		output.append("NoTag[");
-		output.append(keyPattern.pattern());
-		output.append(",");
-		output.append(valuePattern.pattern());
+		output.append("Ids[");
+		int i = 0;
+		for (Long id: ids) {
+			if (++i>1) {
+				output.append(",");
+			}
+			if (i>5) {
+				output.append("...");
+				break;
+			}
+			output.append(id);
+		}
 		output.append("]: ");
 		output.append(matchHits);
 		output.append('\n');

--- a/osmosis-tagtransform/src/main/java/org/openstreetmap/osmosis/tagtransform/impl/OrMatcher.java
+++ b/osmosis-tagtransform/src/main/java/org/openstreetmap/osmosis/tagtransform/impl/OrMatcher.java
@@ -29,8 +29,8 @@ public class OrMatcher implements Matcher {
 
 
 	@Override
-	public Collection<Match> match(Map<String, String> tags, TTEntityType entityType, String entityUname,
-			int entityUid) {
+	public Collection<Match> match(long entityId, Map<String, String> tags, TTEntityType entityType, String entityUname,
+                                   int entityUid) {
 		if (this.type != null && this.type != entityType) {
 			return null;
 		}
@@ -43,7 +43,7 @@ public class OrMatcher implements Matcher {
 
 		List<Match> allMatches = new ArrayList<Match>();
 		for (Matcher matcher : matchers) {
-			Collection<Match> matches = matcher.match(tags, entityType, entityUname, entityUid);
+			Collection<Match> matches = matcher.match(entityId, tags, entityType, entityUname, entityUid);
 			if (matches != null) {
 				allMatches.addAll(matches);
 			}

--- a/osmosis-tagtransform/src/main/java/org/openstreetmap/osmosis/tagtransform/impl/TagMatcher.java
+++ b/osmosis-tagtransform/src/main/java/org/openstreetmap/osmosis/tagtransform/impl/TagMatcher.java
@@ -30,7 +30,7 @@ public class TagMatcher implements Matcher {
 
 
 	@Override
-	public Collection<Match> match(Map<String, String> tags, TTEntityType type, String uname, int uid) {
+	public Collection<Match> match(long id, Map<String, String> tags, TTEntityType type, String uname, int uid) {
 		List<Match> matches = new ArrayList<Match>();
 
 		// loop through the tags to find matches

--- a/osmosis-tagtransform/src/main/java/org/openstreetmap/osmosis/tagtransform/impl/TransformHelper.java
+++ b/osmosis-tagtransform/src/main/java/org/openstreetmap/osmosis/tagtransform/impl/TransformHelper.java
@@ -117,6 +117,7 @@ public abstract class TransformHelper<T extends Task & Initializable> implements
 		Entity entity = entityContainer.getEntity();
 		Collection<Tag> entityTags = entity.getTags();
 		EntityType entityType = entity.getType();
+		long id = entity.getId();
 
 		// Store the tags in a map keyed by tag key.
 		Map<String, String> tagMap = new HashMap<String, String>();
@@ -126,7 +127,7 @@ public abstract class TransformHelper<T extends Task & Initializable> implements
 
 		// Apply tag transformations.
 		for (Translation translation : translations) {
-			Collection<Match> matches = translation.match(tagMap, TTEntityType.fromEntityType06(entityType), entity
+			Collection<Match> matches = translation.match(id, tagMap, TTEntityType.fromEntityType06(entityType), entity
 					.getUser().getName(), entity.getUser().getId());
 			if (matches == null || matches.isEmpty()) {
 				continue;

--- a/osmosis-tagtransform/src/main/java/org/openstreetmap/osmosis/tagtransform/impl/TransformLoader.java
+++ b/osmosis-tagtransform/src/main/java/org/openstreetmap/osmosis/tagtransform/impl/TransformLoader.java
@@ -3,7 +3,9 @@ package org.openstreetmap.osmosis.tagtransform.impl;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Logger;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -154,8 +156,26 @@ public class TransformLoader {
 			String k = matcher.getAttribute("k");
 			String v = matcher.getAttribute("v");
 			return new NoTagMatcher(k, v);
+		} else if (name.equals("ids")) {
+			return parseIds(matcher);
 		}
 		return null;
+	}
+
+	private Matcher parseIds(Element idsElement) {
+		NodeList children = idsElement.getChildNodes();
+		Set<Long> ids = new HashSet<>();
+		for (int i = 0; i < children.getLength(); i++) {
+			if (!(children.item(i) instanceof Element)) {
+				continue;
+			}
+			Element element = (Element)children.item(i);
+			if (element.getTagName().equals("id")) {
+				Long id = Long.valueOf(element.getTextContent());
+				ids.add(id);
+			}
+		}
+		return new IdMatcher(ids);
 	}
 
 

--- a/osmosis-tagtransform/src/main/java/org/openstreetmap/osmosis/tagtransform/impl/TranslationImpl.java
+++ b/osmosis-tagtransform/src/main/java/org/openstreetmap/osmosis/tagtransform/impl/TranslationImpl.java
@@ -44,14 +44,14 @@ public class TranslationImpl implements Translation {
 
 
 	@Override
-	public Collection<Match> match(Map<String, String> tags, TTEntityType type, String uname, int uid) {
-		Collection<Match> matches = matcher.match(tags, type, uname, uid);
+	public Collection<Match> match(long id, Map<String, String> tags, TTEntityType type, String uname, int uid) {
+		Collection<Match> matches = matcher.match(id, tags, type, uname, uid);
 		if (matches != null && !matches.isEmpty()) {
 			Collection<Match> finds;
 			if (finder == null) {
 				finds = null;
 			} else {
-				finds = finder.match(tags, type, uname, uid);
+				finds = finder.match(id, tags, type, uname, uid);
 			}
 			if (finds != null && !finds.isEmpty()) {
 				if (matches instanceof ArrayList) {

--- a/osmosis-tagtransform/src/test/resources/data/template/v0_6/test-out.osm
+++ b/osmosis-tagtransform/src/test/resources/data/template/v0_6/test-out.osm
@@ -20,7 +20,9 @@
     <tag k="crossing" v="toucan"/>
     <tag k="highway" v="crossing"/>
   </node>
-  <way id="4" version="1" timestamp="2007-01-29T08:48:14Z"/>
+  <way id="4" version="1" timestamp="2007-01-29T08:48:14Z">
+    <tag k="highway" v="secondary"/>
+  </way>
   <way id="5" version="1" timestamp="2007-01-29T08:48:14Z">
     <tag k="highway" v="motorway"/>
   </way>

--- a/osmosis-tagtransform/src/test/resources/data/template/v0_6/translation.xml
+++ b/osmosis-tagtransform/src/test/resources/data/template/v0_6/translation.xml
@@ -186,5 +186,19 @@
     </output>
   </translation>
  -->
-
+  <translation>
+    <name>Add tag to feature identified by id</name>
+    <description>Add a tag to a specific feature, if it does not exist already</description>
+    <match type="way" mode="and">
+      <ids>
+        <id>4</id>
+        <id>5</id>
+      </ids>
+      <notag k="highway" v=".*"/>
+    </match>
+    <output>
+      <copy-all/>
+      <tag k="highway" v="secondary"/>
+    </output>
+  </translation>
 </translations>


### PR DESCRIPTION
This PR adds ID matching to tag-transform.

Tag-Transformation may be applied to entities with matching osm ID only: 

 ```
...
<match type="way" mode="and">
      <ids>
        <id>4</id>
        <id>5</id>
      </ids>
      <notag k="highway" v=".*"/>
  </match>
...
```
Note: If this PR is accepted, the [tag-transform wiki page](https://wiki.openstreetmap.org/wiki/Osmosis/TagTransform#match) would need to reflect this new functionality.   