### PR TITLE
Fix sporadic failures decompressing gziped files

### DIFF
--- a/osmosis-xml/src/main/java/org/openstreetmap/osmosis/xml/common/CompressionActivator.java
+++ b/osmosis-xml/src/main/java/org/openstreetmap/osmosis/xml/common/CompressionActivator.java
@@ -4,13 +4,12 @@ package org.openstreetmap.osmosis.xml.common;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
-
 import org.openstreetmap.osmosis.core.OsmosisRuntimeException;
-import org.openstreetmap.osmosis.core.util.MultiMemberGZIPInputStream;
 
 
 /**
@@ -85,7 +84,7 @@ public class CompressionActivator {
 			}
 			
 			if (CompressionMethod.GZip.equals(compressionMethod)) {
-				return new MultiMemberGZIPInputStream(sourceStream);
+				return new GZIPInputStream(sourceStream, 4096);
 			}
 			
 			if (CompressionMethod.BZip2.equals(compressionMethod)) {


### PR DESCRIPTION
Increases the buffer size used by GZipInputStream from 512 (default) to 4096

Notes:

- this is not based on an understanding of the root cause. that would likely require dissecting GZipInputStream (note a simple test decompression program does not show the issue, but as the test reads byte by byte it could very well be an interaction with the read size by the XML parser, but that is Oracles problem).
- http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4691425 seems to be fixed and MultiMemberGZIPInputStream is no longer necessary, it should likely be removed completely, it however has nothing to do with the bug in question.

File causing the issue:

[634.osc.gz](https://github.com/openstreetmap/osmosis/files/3072463/634.osc.gz)
