### PR TITLE
Fix sporadic OSC parsing failures 

### DIFF
--- a/osmosis-core/build.gradle
+++ b/osmosis-core/build.gradle
@@ -8,7 +8,6 @@ dependencies {
     compile group: 'com.fasterxml.woodstox', name: 'woodstox-core', version: dependencyVersionWoodstoxCore
     compile group: 'org.codehaus.woodstox', name: 'stax2-api', version: dependencyVersionWoodstoxStax2
     compile group: 'org.apache.commons', name: 'commons-compress', version: dependencyVersionCommonsCompress
-    compile group: 'xerces', name: 'xercesImpl', version: dependencyVersionXerces
 }
 
 /*


### PR DESCRIPTION
Removing explicit dependency on xerces and using the JDK version fixes the issue that has gone unfixed in the apache version of xerces since 2007, even though a fix is available.

See https://bugs.openjdk.java.net/browse/JDK-8080085

File tickling the issue
[634.osc.gz](https://github.com/openstreetmap/osmosis/files/3074982/634.osc.gz)


