### PR TITLE
Added $gnupgUserDir to Docker setup

### DIFF
--- a/build-support/docker/docker-compose.yml
+++ b/build-support/docker/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - db
     volumes:
       - ${gradleUserDir}:/gradle
+      - ${gnupgUserDir}:${gnupgUserDir}
       - ${projectDir}:/project
   db:
     image: openstreetmap.org/osmosis-db

--- a/build-support/docker/env.sh
+++ b/build-support/docker/env.sh
@@ -1,4 +1,5 @@
 export gradleUserDir="${HOME}/.gradle"
+export gnupgUserDir="${HOME}/.gnupg"
 export userId=$(id -u)
 export groupId=$(id -g)
 export projectDir="$( cd "${scriptDir}"/../.. && pwd )"


### PR DESCRIPTION
Mounting the ~/.gnupg directory enables meaningful paths in ~/.gradle/gradle.properties when running releases from inside Docker.