### PR TITLE
Adding ability to use Osmosis as a library with limited functionality.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,12 @@
+buildscript {
+	repositories {
+		jcenter()
+	}
+	dependencies {
+		classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.1'
+	}
+}
+
 apply plugin: 'idea'
 
 /* Build collections containing each type of project.  These collections will
@@ -35,6 +44,7 @@ configure(javaProjects) {
 	apply plugin: 'jdepend'
 	apply plugin: 'maven'
 	apply plugin: 'signing'
+	apply plugin: 'com.github.johnrengelman.shadow'
 
 	sourceCompatibility = 1.8
 
@@ -75,6 +85,15 @@ configure(javaProjects) {
 
 	    archives javadocJar
 	    archives sourcesJar
+	}
+
+	shadowJar {
+		baseName = project.name
+		mergeServiceFiles()
+		transform(com.github.jengelman.gradle.plugins.shadow.transformers.AppendingTransformer) {
+			resource = 'reference.conf'
+		}
+		zip64 = true
 	}
 
 	// Sign all published artifacts if signing is enabled.

--- a/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/TaskRegistrar.java
+++ b/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/TaskRegistrar.java
@@ -88,6 +88,20 @@ public class TaskRegistrar {
 		loadJPFPlugins();
 	}
 
+	/**
+	 * Loads a plugin manually.
+	 * 
+	 * @param pluginLoader The pluginLoader that you wish to load.
+	 */
+	public void loadPlugin(final PluginLoader pluginLoader) {
+		final Map<String, TaskManagerFactory> pluginTasks = pluginLoader.loadTaskFactories();
+		// register the plugin tasks
+		pluginTasks.entrySet().forEach(task -> {
+			if (!this.factoryRegister.containsTaskType(task.getKey())) {
+				this.factoryRegister.register(task.getKey(), task.getValue());
+			}
+		});
+	}
 
 	private void loadBuiltInPlugins() {
 		final String pluginResourceName = "osmosis-plugins.conf";

--- a/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/pipeline/common/TaskManagerFactoryRegister.java
+++ b/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/pipeline/common/TaskManagerFactoryRegister.java
@@ -47,6 +47,15 @@ public class TaskManagerFactoryRegister {
 		factoryMap.put(taskType, factory);
 	}
 	
+	/**
+	 * Basic check to see if the factory map contains a task type of not.
+	 * 
+	 * @param taskType The taskType to check for.
+	 * @return True if already contains the taskType.
+	 */
+	public boolean containsTaskType(final String taskType) {
+		return this.factoryMap.containsKey(taskType);
+	}
 	
 	/**
 	 * Get a task manager factory from the register.

--- a/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/runner/OsmosisRunner.java
+++ b/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/runner/OsmosisRunner.java
@@ -1,0 +1,63 @@
+// This software is released into the Public Domain.  See copying.txt for details.
+package org.openstreetmap.osmosis.core.runner;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.openstreetmap.osmosis.core.Osmosis;
+import org.openstreetmap.osmosis.core.OsmosisConstants;
+import org.openstreetmap.osmosis.core.TaskRegistrar;
+import org.openstreetmap.osmosis.core.pipeline.common.Pipeline;
+import org.openstreetmap.osmosis.core.pipeline.common.TaskConfiguration;
+
+/**
+ * Class to run a specific type of Osmosis within Java.
+ *
+ * @author mcuthbert
+ */
+public class OsmosisRunner implements Runnable {
+    private static final Logger LOG = Logger.getLogger(Osmosis.class.getName());
+    private final OsmosisTask inTask;
+    private final OsmosisTask outTask;
+
+    /**
+     * Standard Constructor. 
+     * Todo: This can easily be extended to take a list of tasks and add them all to the pipeline
+     *
+     * @param inTask The in Task
+     * @param outTask The out Task
+     */
+    public OsmosisRunner(final OsmosisTask inTask, final OsmosisTask outTask) {
+        this.inTask = inTask;
+        this.outTask = outTask;
+    }
+
+    @Override
+    public void run() {
+        final long startTime = System.currentTimeMillis();
+        LOG.info("Osmosis Version " + OsmosisConstants.VERSION);
+        final TaskRegistrar taskRegistrar = new TaskRegistrar();
+        taskRegistrar.loadPlugin(this.inTask.getLoader());
+        taskRegistrar.loadPlugin(this.outTask.getLoader());
+        final Pipeline pipeline = new Pipeline(taskRegistrar.getFactoryRegister());
+
+        LOG.info("Preparing pipeline.");
+        final List<TaskConfiguration> taskConfigurations = new ArrayList<>();
+        taskConfigurations.add(this.inTask.getTaskConfiguration(1));
+        taskConfigurations.add(this.outTask.getTaskConfiguration(2));
+
+        pipeline.prepare(taskConfigurations);
+
+        LOG.info("Launching pipeline execution.");
+        pipeline.execute();
+
+        LOG.info("Pipeline executing, waiting for completion.");
+        pipeline.waitForCompletion();
+
+        LOG.info("Pipeline complete.");
+
+        LOG.info("Total execution time: " + (System.currentTimeMillis() - startTime)
+                + " milliseconds.");
+    }
+}

--- a/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/runner/OsmosisTask.java
+++ b/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/runner/OsmosisTask.java
@@ -1,0 +1,71 @@
+// This software is released into the Public Domain.  See copying.txt for details.
+package org.openstreetmap.osmosis.core.runner;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.openstreetmap.osmosis.core.pipeline.common.TaskConfiguration;
+import org.openstreetmap.osmosis.core.plugin.PluginLoader;
+
+/**
+ * A task for Osmosis to execute.
+ *
+ * @author mcuthbert
+ */
+public class OsmosisTask {
+    private final PluginLoader loader;
+    private final String name;
+    private final Map<String, String> arguments;
+
+    /**
+     * Standard Constructor.
+     *
+     * @param loader The plugin loader containing the task
+     * @param name The name of the task
+     * @param arguments arguments supplied for the task
+     */
+    public OsmosisTask(final PluginLoader loader, final String name,
+            final Map<String, String> arguments) {
+        this.loader = loader;
+        this.name = name;
+        this.arguments = arguments;
+    }
+
+    /**
+     * Getter for the loader for the task.
+     *
+     * @return {@link PluginLoader}
+     */
+    public PluginLoader getLoader() {
+        return loader;
+    }
+
+    /**
+     * Getter for the name, or taskType.
+     *
+     * @return The name of the TaskType
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Getter for the map of arguments for the task.
+     *
+     * @return Map containing key for argument with the matching value
+     */
+    public Map<String, String> getArguments() {
+        return arguments;
+    }
+
+    /**
+     * Builds a {@link TaskConfiguration} based on the task.
+     *
+     * @param taskId A unique id for the task
+     * @return {@link TaskConfiguration}
+     */
+    public TaskConfiguration getTaskConfiguration(final int taskId) {
+        return new TaskConfiguration(taskId + "-" + this.name, this.name, Collections.emptyMap(),
+                this.arguments, null);
+    }
+}


### PR DESCRIPTION
This PR adds the ability to run Osmosis as a library within another JVM language. 

Example:
```java
final OsmosisTask task1 = new OsmosisTask(new XmlPluginLoader(), "read-xml-change", <MAP OF ARGUMENTS>);
final OsmosisTask task2 = new OsmosisTask(new PgSnapshotPluginLoader(), "write-pgsql-change", <MAP OF ARGUMENTS>);
final OsmosisRunner runner = new OsmosisRunner(task1, task2);
runner.run();
```

The <MAP OF ARGUMENTS> variable would simply be the key value pair strings that you would ordinarily send in along with the task.