### PR TITLE
State Management Flexibility

### DIFF
--- a/osmosis-replication/src/main/java/org/openstreetmap/osmosis/replication/ReplicationPluginLoader.java
+++ b/osmosis-replication/src/main/java/org/openstreetmap/osmosis/replication/ReplicationPluginLoader.java
@@ -31,7 +31,7 @@ public class ReplicationPluginLoader implements PluginLoader {
 	public Map<String, TaskManagerFactory> loadTaskFactories() {
 		Map<String, TaskManagerFactory> factoryMap;
 		
-		factoryMap = new HashMap<String, TaskManagerFactory>();
+		factoryMap = new HashMap<>();
 		
 		factoryMap.put("read-change-interval", new IntervalDownloaderFactory());
 		factoryMap.put("rci", new IntervalDownloaderFactory());

--- a/osmosis-replication/src/main/java/org/openstreetmap/osmosis/replication/v0_6/ReplicationDownloader.java
+++ b/osmosis-replication/src/main/java/org/openstreetmap/osmosis/replication/v0_6/ReplicationDownloader.java
@@ -32,9 +32,11 @@ public class ReplicationDownloader extends BaseReplicationDownloader implements 
 	 * 
 	 * @param workingDirectory
 	 *            The directory containing configuration and tracking files.
+	 * @param single
+	 * 			  Set to true if you want to only replicate a single diff file from the server
 	 */
-	public ReplicationDownloader(File workingDirectory) {
-		super(workingDirectory);
+	public ReplicationDownloader(File workingDirectory, boolean single) {
+		super(workingDirectory, single);
 		
 		// We will sort all contents prior to sending to the sink. This adds overhead that may not
 		// always be required, but provides consistent behaviour.

--- a/osmosis-replication/src/main/java/org/openstreetmap/osmosis/replication/v0_6/ReplicationDownloaderFactory.java
+++ b/osmosis-replication/src/main/java/org/openstreetmap/osmosis/replication/v0_6/ReplicationDownloaderFactory.java
@@ -9,16 +9,21 @@ import org.openstreetmap.osmosis.core.pipeline.v0_6.RunnableChangeSourceManager;
  * The task manager factory for a replication file downloader.
  */
 public class ReplicationDownloaderFactory extends WorkingTaskManagerFactory {
+	private static final String ARG_SINGLE = "single";
+	private static final boolean DEFAULT_SINGLE = false;
 	
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
 	protected TaskManager createTaskManagerImpl(TaskConfiguration taskConfig) {
+		boolean single = getBooleanArgument(taskConfig, ARG_SINGLE, DEFAULT_SINGLE);	
+
 		return new RunnableChangeSourceManager(
 			taskConfig.getId(),
 			new ReplicationDownloader(
-				this.getWorkingDirectory(taskConfig)
+				this.getWorkingDirectory(taskConfig),
+				single
 			),
 			taskConfig.getPipeArgs()
 		);

--- a/osmosis-replication/src/main/java/org/openstreetmap/osmosis/replication/v0_6/ReplicationFileMerger.java
+++ b/osmosis-replication/src/main/java/org/openstreetmap/osmosis/replication/v0_6/ReplicationFileMerger.java
@@ -42,9 +42,11 @@ public class ReplicationFileMerger extends BaseReplicationDownloader {
 	 * 
 	 * @param workingDirectory
 	 *            The directory containing configuration and tracking files.
+	 * @param single
+	 * 			  Set to true if you want to only replicate a single diff file from the server
 	 */
-	public ReplicationFileMerger(File workingDirectory) {
-		super(workingDirectory);
+	public ReplicationFileMerger(File workingDirectory, boolean single) {
+		super(workingDirectory, single);
 		
 		replicationStore = new FileReplicationStore(new File(getWorkingDirectory(), DATA_DIRECTORY), true);
 

--- a/osmosis-replication/src/main/java/org/openstreetmap/osmosis/replication/v0_6/ReplicationFileMergerFactory.java
+++ b/osmosis-replication/src/main/java/org/openstreetmap/osmosis/replication/v0_6/ReplicationFileMergerFactory.java
@@ -10,16 +10,21 @@ import org.openstreetmap.osmosis.core.pipeline.common.TaskManager;
  * The task manager factory for a replication file merger.
  */
 public class ReplicationFileMergerFactory extends WorkingTaskManagerFactory {
-	
+	private static final String ARG_SINGLE = "single";
+	private static final boolean DEFAULT_SINGLE = false;
+
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
 	protected TaskManager createTaskManagerImpl(TaskConfiguration taskConfig) {
+		boolean single = getBooleanArgument(taskConfig, ARG_SINGLE, DEFAULT_SINGLE);
+
 		return new RunnableTaskManager(
 			taskConfig.getId(),
 			new ReplicationFileMerger(
-				this.getWorkingDirectory(taskConfig)
+				this.getWorkingDirectory(taskConfig),
+				single
 			),
 			taskConfig.getPipeArgs()
 		);


### PR DESCRIPTION
This is a fairly simple PR that just gives a little bit of flexibility to the replication module allowing users to do two things:
1. Download a single replication file at a time
This just gives added flexibility and very useful if you are either debugging a specific issue with replication or simply controlling specifically the replication process. 

2. Allow a user to set a custom server state file locally instead of depend on the remote state.
This again allows great flexibility in debugging issues, as you can replicate up to a certain point and by setting your local state file and the new custom state file you can replicate only between two points in time.

