### PR TITLE
Fix link in gradle-wrapper.properties 0.43.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.4-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-1.4-bin.zip


### PR DESCRIPTION
Need to update the link in gradle-wrapper.properties in version 0.43.1 