### PR TITLE
Adding advanced database logging for PgSnapshot module

### DIFF
--- a/build-support/docker/db/docker-start.sh
+++ b/build-support/docker/db/docker-start.sh
@@ -53,6 +53,7 @@ if [ ! "$(ls -A $DATADIR)" ]; then
 		\i /install/script/pgsnapshot_schema_0.6_action.sql
 		\i /install/script/pgsnapshot_schema_0.6_bbox.sql
 		\i /install/script/pgsnapshot_schema_0.6_linestring.sql
+		\i /install/script/pgsnapshot_schema_0.6_changes.sql
 	EOSQL
 
 	# Configure the pgosmsnap06_test_with_schema database as the OSM user.
@@ -65,6 +66,7 @@ if [ ! "$(ls -A $DATADIR)" ]; then
 		\i /install/script/pgsnapshot_schema_0.6_action.sql
 		\i /install/script/pgsnapshot_schema_0.6_bbox.sql
 		\i /install/script/pgsnapshot_schema_0.6_linestring.sql
+		\i /install/script/pgsnapshot_schema_0.6_changes.sql
 	EOSQL
 
 	# Configure the api06_test database as the OSM user.

--- a/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/PostgreSqlChangeWriter.java
+++ b/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/PostgreSqlChangeWriter.java
@@ -1,13 +1,20 @@
 // This software is released into the Public Domain.  See copying.txt for details.
 package org.openstreetmap.osmosis.pgsnapshot.v0_6;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.openstreetmap.osmosis.core.OsmosisRuntimeException;
 import org.openstreetmap.osmosis.core.container.v0_6.ChangeContainer;
 import org.openstreetmap.osmosis.core.database.DatabaseLoginCredentials;
 import org.openstreetmap.osmosis.core.database.DatabasePreferences;
+import org.openstreetmap.osmosis.core.domain.v0_6.Entity;
+import org.openstreetmap.osmosis.core.domain.v0_6.EntityType;
 import org.openstreetmap.osmosis.core.task.common.ChangeAction;
 import org.openstreetmap.osmosis.core.task.v0_6.ChangeSink;
 import org.openstreetmap.osmosis.pgsnapshot.common.DatabaseContext;
@@ -24,12 +31,18 @@ import org.openstreetmap.osmosis.pgsnapshot.v0_6.impl.ChangeWriter;
  * @author Brett Henderson
  */
 public class PostgreSqlChangeWriter implements ChangeSink {
+
+	private static final SimpleDateFormat FORMATTER = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 	
 	private ChangeWriter changeWriter;
 	private Map<ChangeAction, ActionChangeWriter> actionWriterMap;
 	private DatabaseContext dbCtx;
 	private SchemaVersionValidator schemaVersionValidator;
 	private boolean initialized;
+	private final Set<Long> appliedChangeSets;
+ 	private long earliestTimestamp = 9999999999999L;
+	private long latestTimestamp = 0L;
+	private final Map<String, Integer> modifications;
 	
 	
 	/**
@@ -43,11 +56,14 @@ public class PostgreSqlChangeWriter implements ChangeSink {
 	 *            If true, zero and single node ways are kept. Otherwise they are
 	 *            silently dropped to avoid putting invalid geometries into the 
 	 *            database which can cause problems with postgis functions.
+	 * @param logging
+	 * 			  If true, will log all sql queries to the database that was executed
+	 * 			  from the change log
 	 */
 	public PostgreSqlChangeWriter(DatabaseLoginCredentials loginCredentials, 
-			DatabasePreferences preferences, boolean keepInvalidWays) {
+			DatabasePreferences preferences, boolean keepInvalidWays, boolean logging) {
 		dbCtx = new DatabaseContext(loginCredentials);
-		changeWriter = new ChangeWriter(dbCtx);
+		changeWriter = new ChangeWriter(dbCtx, logging);
 		actionWriterMap = new HashMap<ChangeAction, ActionChangeWriter>();
 		actionWriterMap.put(ChangeAction.Create, 
 				new ActionChangeWriter(changeWriter, ChangeAction.Create, keepInvalidWays));
@@ -57,7 +73,8 @@ public class PostgreSqlChangeWriter implements ChangeSink {
 				new ActionChangeWriter(changeWriter, ChangeAction.Delete, keepInvalidWays));
 		
 		schemaVersionValidator = new SchemaVersionValidator(dbCtx.getJdbcTemplate(), preferences);
-		
+		appliedChangeSets = new HashSet<>();
+		modifications = new HashMap<>();
 		initialized = false;
 	}
 	
@@ -95,6 +112,15 @@ public class PostgreSqlChangeWriter implements ChangeSink {
 		if (!actionWriterMap.containsKey(action)) {
 			throw new OsmosisRuntimeException("The action " + action + " is unrecognized.");
 		}
+
+		final Entity entity = change.getEntityContainer().getEntity();
+		this.appliedChangeSets.add(entity.getChangesetId());
+		this.earliestTimestamp = Math.min(this.earliestTimestamp, entity.getTimestamp().getTime());
+		this.latestTimestamp = Math.max(this.latestTimestamp, entity.getTimestamp().getTime());
+
+ 		final String name = entity.getType().name() + "-" + action.name();
+		final int count = modifications.getOrDefault(name, 0) + 1;
+		modifications.put(name, count);
 		
 		// Process the entity using the action writer appropriate for the change
 		// action.
@@ -109,6 +135,26 @@ public class PostgreSqlChangeWriter implements ChangeSink {
 		initialize();
 		
 		changeWriter.complete();
+
+		// on complete write to the changes table
+		dbCtx.getJdbcTemplate().execute(String.format("INSERT INTO replication_changes "
+                + "(nodes_added, nodes_modified, nodes_deleted, "
+				+ "ways_added, ways_modified, ways_deleted, "
+				+ "relations_added, relations_modified, relations_deleted, "
+				+ "changesets_applied, earliest_timestamp, latest_timestamp) "
+                + "VALUES "
+                + "(%s, %s, %s, %s, %s, %s, %s, %s, %s, ARRAY[%s]::BIGINT[], '%s', '%s')",
+                modifications.getOrDefault(EntityType.Node.name() + "-" + ChangeAction.Create, 0),
+				modifications.getOrDefault(EntityType.Node.name() + "-" + ChangeAction.Modify, 0),
+				modifications.getOrDefault(EntityType.Node.name() + "-" + ChangeAction.Delete, 0),
+				modifications.getOrDefault(EntityType.Way.name() + "-" + ChangeAction.Create, 0),
+				modifications.getOrDefault(EntityType.Way.name() + "-" + ChangeAction.Modify, 0),
+				modifications.getOrDefault(EntityType.Way.name() + "-" + ChangeAction.Delete, 0),
+				modifications.getOrDefault(EntityType.Relation.name() + "-" + ChangeAction.Create, 0),
+				modifications.getOrDefault(EntityType.Relation.name() + "-" + ChangeAction.Modify, 0),
+				modifications.getOrDefault(EntityType.Relation.name() + "-" + ChangeAction.Delete, 0),
+		appliedChangeSets.stream().map(id -> id + "").collect(Collectors.joining(",")),
+				FORMATTER.format(new Date(earliestTimestamp)), FORMATTER.format(new Date(latestTimestamp))));
 		
 		dbCtx.commitTransaction();
 	}

--- a/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/PostgreSqlChangeWriterFactory.java
+++ b/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/PostgreSqlChangeWriterFactory.java
@@ -18,27 +18,24 @@ public class PostgreSqlChangeWriterFactory extends DatabaseTaskManagerFactory {
 	
 	private static final String ARG_KEEP_INVALID_WAYS = "keepInvalidWays";
 	private static final boolean DEFAULT_KEEP_INVALID_WAYS = true;
+	private static final String ARG_LOGGING = "logging";
+	private static final boolean DEFAULT_LOGGING = false;
 	
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
 	protected TaskManager createTaskManagerImpl(TaskConfiguration taskConfig) {
-		DatabaseLoginCredentials loginCredentials;
-		DatabasePreferences preferences;
-		
-		// Get the task arguments.
-		loginCredentials = getDatabaseLoginCredentials(taskConfig);
-		preferences = getDatabasePreferences(taskConfig);
-		
 		boolean keepInvalidWays = getBooleanArgument(taskConfig, ARG_KEEP_INVALID_WAYS, DEFAULT_KEEP_INVALID_WAYS);
+		boolean logging = getBooleanArgument(taskConfig, ARG_LOGGING, DEFAULT_LOGGING);
 		
 		return new ChangeSinkManager(
 			taskConfig.getId(),
 			new PostgreSqlChangeWriter(
-				loginCredentials,
-				preferences,
-				keepInvalidWays
+				getDatabaseLoginCredentials(taskConfig),
+				getDatabasePreferences(taskConfig),
+				keepInvalidWays,
+				logging
 			),
 			taskConfig.getPipeArgs()
 		);

--- a/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/PostgreSqlChangeWriterFactory.java
+++ b/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/PostgreSqlChangeWriterFactory.java
@@ -1,8 +1,6 @@
 // This software is released into the Public Domain.  See copying.txt for details.
 package org.openstreetmap.osmosis.pgsnapshot.v0_6;
 
-import org.openstreetmap.osmosis.core.database.DatabaseLoginCredentials;
-import org.openstreetmap.osmosis.core.database.DatabasePreferences;
 import org.openstreetmap.osmosis.core.database.DatabaseTaskManagerFactory;
 import org.openstreetmap.osmosis.core.pipeline.common.TaskConfiguration;
 import org.openstreetmap.osmosis.core.pipeline.common.TaskManager;

--- a/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/PostgreSqlCopyWriterFactory.java
+++ b/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/PostgreSqlCopyWriterFactory.java
@@ -1,8 +1,6 @@
 // This software is released into the Public Domain.  See copying.txt for details.
 package org.openstreetmap.osmosis.pgsnapshot.v0_6;
 
-import org.openstreetmap.osmosis.core.database.DatabaseLoginCredentials;
-import org.openstreetmap.osmosis.core.database.DatabasePreferences;
 import org.openstreetmap.osmosis.core.database.DatabaseTaskManagerFactory;
 import org.openstreetmap.osmosis.pgsnapshot.common.NodeLocationStoreType;
 import org.openstreetmap.osmosis.core.pipeline.common.TaskConfiguration;

--- a/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/PostgreSqlCopyWriterFactory.java
+++ b/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/PostgreSqlCopyWriterFactory.java
@@ -26,14 +26,9 @@ public class PostgreSqlCopyWriterFactory extends DatabaseTaskManagerFactory {
 	 */
 	@Override
 	protected TaskManager createTaskManagerImpl(TaskConfiguration taskConfig) {
-		DatabaseLoginCredentials loginCredentials;
-		DatabasePreferences preferences;
 		NodeLocationStoreType storeType;
 		boolean keepInvalidWays;
-		
-		// Get the task arguments.
-		loginCredentials = getDatabaseLoginCredentials(taskConfig);
-		preferences = getDatabasePreferences(taskConfig);
+
 		storeType = Enum.valueOf(
 				NodeLocationStoreType.class,
 				getStringArgument(taskConfig, ARG_NODE_LOCATION_STORE_TYPE, DEFAULT_NODE_LOCATION_STORE_TYPE));
@@ -41,7 +36,11 @@ public class PostgreSqlCopyWriterFactory extends DatabaseTaskManagerFactory {
 		
 		return new SinkManager(
 			taskConfig.getId(),
-			new PostgreSqlCopyWriter(loginCredentials, preferences,	storeType, keepInvalidWays),
+			new PostgreSqlCopyWriter(
+				getDatabaseLoginCredentials(taskConfig), 
+				getDatabasePreferences(taskConfig),	
+				storeType, 
+				keepInvalidWays),
 			taskConfig.getPipeArgs()
 		);
 	}

--- a/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/PostgreSqlDatasetReader.java
+++ b/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/PostgreSqlDatasetReader.java
@@ -63,6 +63,6 @@ public class PostgreSqlDatasetReader implements RunnableDatasetSource, Dataset {
 	 */
 	@Override
 	public DatasetContext createReader() {
-		return new PostgreSqlDatasetContext(loginCredentials, preferences);
+		return new PostgreSqlDatasetContext(loginCredentials, preferences, false);
 	}
 }

--- a/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/PostgreSqlDatasetReaderFactory.java
+++ b/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/PostgreSqlDatasetReaderFactory.java
@@ -21,16 +21,11 @@ public class PostgreSqlDatasetReaderFactory extends DatabaseTaskManagerFactory {
 	 */
 	@Override
 	protected TaskManager createTaskManagerImpl(TaskConfiguration taskConfig) {
-		DatabaseLoginCredentials loginCredentials;
-		DatabasePreferences preferences;
-		
-		// Get the task arguments.
-		loginCredentials = getDatabaseLoginCredentials(taskConfig);
-		preferences = getDatabasePreferences(taskConfig);
-		
 		return new RunnableDatasetSourceManager(
 			taskConfig.getId(),
-			new PostgreSqlDatasetReader(loginCredentials, preferences),
+			new PostgreSqlDatasetReader(
+				getDatabaseLoginCredentials(taskConfig), 
+				getDatabasePreferences(taskConfig)),
 			taskConfig.getPipeArgs()
 		);
 	}

--- a/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/PostgreSqlDatasetReaderFactory.java
+++ b/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/PostgreSqlDatasetReaderFactory.java
@@ -1,8 +1,6 @@
 // This software is released into the Public Domain.  See copying.txt for details.
 package org.openstreetmap.osmosis.pgsnapshot.v0_6;
 
-import org.openstreetmap.osmosis.core.database.DatabaseLoginCredentials;
-import org.openstreetmap.osmosis.core.database.DatabasePreferences;
 import org.openstreetmap.osmosis.core.database.DatabaseTaskManagerFactory;
 import org.openstreetmap.osmosis.core.pipeline.common.TaskConfiguration;
 import org.openstreetmap.osmosis.core.pipeline.common.TaskManager;

--- a/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/impl/ChangeWriter.java
+++ b/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/impl/ChangeWriter.java
@@ -42,15 +42,17 @@ public class ChangeWriter {
 	 * 
 	 * @param dbCtx
 	 *            The database context to use for accessing the database.
+	 * @param logging
+	 * 			  Verbose logging directly to the database
 	 */
-	public ChangeWriter(DatabaseContext dbCtx) {
+	public ChangeWriter(DatabaseContext dbCtx, boolean logging) {
 		this.dbCtx = dbCtx;
 		
 		actionDao = new ActionDao(dbCtx);
 		userDao = new UserDao(dbCtx, actionDao);
-		nodeDao = new NodeDao(dbCtx, actionDao);
-		wayDao = new WayDao(dbCtx, actionDao);
-		relationDao = new RelationDao(dbCtx, actionDao);
+		nodeDao = new NodeDao(dbCtx, actionDao, logging);
+		wayDao = new WayDao(dbCtx, actionDao, logging);
+		relationDao = new RelationDao(dbCtx, actionDao, logging);
 		
 		userSet = new HashSet<Integer>();
 	}

--- a/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/impl/NodeDao.java
+++ b/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/impl/NodeDao.java
@@ -48,9 +48,11 @@ public class NodeDao extends EntityDao<Node> {
 	 *            The database context to use for accessing the database.
 	 * @param actionDao
 	 *            The dao to use for adding action records to the database.
+	 * @param logging
+	 * 			  Verbose logging directly to the database
 	 */
-	public NodeDao(DatabaseContext dbCtx, ActionDao actionDao) {
-		super(dbCtx.getJdbcTemplate(), new NodeMapper(), actionDao);
+	public NodeDao(DatabaseContext dbCtx, ActionDao actionDao, boolean logging) {
+		super(dbCtx.getJdbcTemplate(), new NodeMapper(), actionDao, logging);
 		
 		jdbcTemplate = dbCtx.getJdbcTemplate();
 		capabilityChecker = new DatabaseCapabilityChecker(dbCtx);

--- a/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/impl/PostgreSqlDatasetContext.java
+++ b/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/impl/PostgreSqlDatasetContext.java
@@ -64,7 +64,7 @@ public class PostgreSqlDatasetContext implements DatasetContext {
 	private PostgreSqlEntityManager<Way> wayManager;
 	private PostgreSqlEntityManager<Relation> relationManager;
 	private PolygonBuilder polygonBuilder;
-	
+	private boolean logging;
 	
 	/**
 	 * Creates a new instance.
@@ -73,14 +73,19 @@ public class PostgreSqlDatasetContext implements DatasetContext {
 	 *            Contains all information required to connect to the database.
 	 * @param preferences
 	 *            Contains preferences configuring database behaviour.
+	 * @param logging
+	 * 			  Verbose logging directly to the database
 	 */
-	public PostgreSqlDatasetContext(DatabaseLoginCredentials loginCredentials, DatabasePreferences preferences) {
+	public PostgreSqlDatasetContext(DatabaseLoginCredentials loginCredentials, 
+					DatabasePreferences preferences, boolean logging) {
 		this.loginCredentials = loginCredentials;
 		this.preferences = preferences;
 		
 		polygonBuilder = new PolygonBuilder();
 		
 		initialized = false;
+
+		this.logging = logging;
 	}
 	
 	
@@ -103,13 +108,13 @@ public class PostgreSqlDatasetContext implements DatasetContext {
 			
 			actionDao = new ActionDao(dbCtx);
 			userDao = new UserDao(dbCtx, actionDao);
-			nodeDao = new NodeDao(dbCtx, actionDao);
-			wayDao = new WayDao(dbCtx, actionDao);
-			relationDao = new RelationDao(dbCtx, actionDao);
+			nodeDao = new NodeDao(dbCtx, actionDao, this.logging);
+			wayDao = new WayDao(dbCtx, actionDao, this.logging);
+			relationDao = new RelationDao(dbCtx, actionDao, this.logging);
 			
-			nodeManager = new PostgreSqlEntityManager<Node>(nodeDao, userDao);
-			wayManager = new PostgreSqlEntityManager<Way>(wayDao, userDao);
-			relationManager = new PostgreSqlEntityManager<Relation>(relationDao, userDao);
+			nodeManager = new PostgreSqlEntityManager<>(nodeDao, userDao);
+			wayManager = new PostgreSqlEntityManager<>(wayDao, userDao);
+			relationManager = new PostgreSqlEntityManager<>(relationDao, userDao);
 		}
 		
 		initialized = true;

--- a/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/impl/RelationDao.java
+++ b/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/impl/RelationDao.java
@@ -40,9 +40,11 @@ public class RelationDao extends EntityDao<Relation> {
 	 *            The database context to use for accessing the database.
 	 * @param actionDao
 	 *            The dao to use for adding action records to the database.
+	 * @param logging
+	 * 			  Verbose logging directly to the database
 	 */
-	public RelationDao(DatabaseContext dbCtx, ActionDao actionDao) {
-		super(dbCtx.getJdbcTemplate(), new RelationMapper(), actionDao);
+	public RelationDao(DatabaseContext dbCtx, ActionDao actionDao, boolean logging) {
+		super(dbCtx.getJdbcTemplate(), new RelationMapper(), actionDao, logging);
 		
 		jdbcTemplate = dbCtx.getJdbcTemplate();
 		relationMemberMapper = new RelationMemberMapper();

--- a/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/impl/WayDao.java
+++ b/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/impl/WayDao.java
@@ -49,9 +49,11 @@ public class WayDao extends EntityDao<Way> {
 	 *            The database context to use for accessing the database.
 	 * @param actionDao
 	 *            The dao to use for adding action records to the database.
+	 * @param logging
+	 * 			  Verbose logging directly to the database
 	 */
-	public WayDao(DatabaseContext dbCtx, ActionDao actionDao) {
-		super(dbCtx.getJdbcTemplate(), new WayMapper(), actionDao);
+	public WayDao(DatabaseContext dbCtx, ActionDao actionDao, boolean logging) {
+		super(dbCtx.getJdbcTemplate(), new WayMapper(), actionDao, logging);
 		
 		jdbcTemplate = dbCtx.getJdbcTemplate();
 		capabilityChecker = new DatabaseCapabilityChecker(dbCtx);

--- a/package/script/pgsnapshot_schema_0.6_changes.sql
+++ b/package/script/pgsnapshot_schema_0.6_changes.sql
@@ -1,0 +1,33 @@
+DROP TABLE IF EXISTS replication_changes;
+
+-- Create a table for replication changes that are applied to the database.
+CREATE TABLE replication_changes (
+    id SERIAL,
+    tstamp TIMESTAMP without time zone NOT NULL DEFAULT(NOW()),
+    nodes_modified INT NOT NULL DEFAULT (0),
+    nodes_added INT NOT NULL DEFAULT (0),
+    nodes_deleted INT NOT NULL DEFAULT (0),
+    ways_modified INT NOT NULL DEFAULT (0),
+    ways_added INT NOT NULL DEFAULT (0),
+    ways_deleted INT NOT NULL DEFAULT (0),
+    relations_modified INT NOT NULL DEFAULT (0),
+    relations_added INT NOT NULL DEFAULT (0),
+    relations_deleted INT NOT NULL DEFAULT (0),
+    changesets_applied BIGINT [] NOT NULL,
+    earliest_timestamp TIMESTAMP without time zone NOT NULL,
+    latest_timestamp TIMESTAMP without time zone NOT NULL
+);
+
+ DROP TABLE IF EXISTS sql_changes;
+
+ CREATE TABLE sql_changes (
+  id SERIAL,
+  tstamp TIMESTAMP without time zone NOT NULL DEFAULT(NOW()),
+  entity_id BIGINT NOT NULL,
+  type TEXT NOT NULL,
+  changeset_id BIGINT NOT NULL,
+  change_time TIMESTAMP NOT NULL,
+  action INT NOT NULL,
+  query text NOT NULL,
+  arguments text
+);


### PR DESCRIPTION
This PR will add two types of logging into the PgSnapshot module in Osmosis.

The first type of logging is always performed and will create a summary of all the entities that have been updated in the database. It will include the following fields:
- nodes_added
- nodes_modified 
- nodes_deleted
- ways_added
- ways_modified
- ways_deleted
- relations_added
- relations_modified
- relations_deleted
- changesets_applied
- earliest_timestamp
- latest_timestamp

This will give you a basic overview of every single update in the database and help debug issues if there are any inconsistencies in the database.

The second big of logging is a bit more advanced and will create a lot of noise/data in the database so only should be used be debugging a specific issue. This will capture all sql queries executed on the database and store in the sql_changes table. An alternate way to do this would be to capture all the sql queries that hit the Postgres database.

Otherwise you would use something like this:
`./osmosis --read-xml-change <INPUT> --write-pgsql-change <INPUT> logging=true`