### PR TITLE
fix placement of table of contents macros

### DIFF
--- a/doc/detailed-usage.adoc
+++ b/doc/detailed-usage.adoc
@@ -1,7 +1,7 @@
-# Detailed Usage
-
 :toc: macro
 :toclevels: 4
+
+# Detailed Usage
 
 This page describes the complete set of command line options available
 for the Osmosis tool.


### PR DESCRIPTION
Adding a heading to the top of the file inadvertently broke the table of
contents.  The config macros must be at the immediate beginning of the
file.