### PR TITLE
Adding database locking functionality

### DIFF
--- a/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/common/DatabaseContext2.java
+++ b/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/common/DatabaseContext2.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.sql.DataSource;
+
 import org.apache.commons.dbcp.BasicDataSource;
 import org.openstreetmap.osmosis.core.OsmosisRuntimeException;
 import org.openstreetmap.osmosis.core.database.DatabaseLoginCredentials;
@@ -64,6 +66,14 @@ public class DatabaseContext2 implements AutoCloseable {
         }
     }
 
+	/**
+	 * Retrieves the data source associated with this database context.
+	 *
+	 * @return {@link DataSource}
+	 */
+	public DataSource getDataSource() {
+		return this.dataSource;
+	}
 
 	private OsmosisRuntimeException createUnknownDbTypeException() {
 		return new OsmosisRuntimeException("Unknown database type " + dbType + ".");

--- a/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/v0_6/ApidbChangeReader.java
+++ b/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/v0_6/ApidbChangeReader.java
@@ -9,6 +9,7 @@ import org.openstreetmap.osmosis.apidb.v0_6.impl.AllEntityDao;
 import org.openstreetmap.osmosis.apidb.v0_6.impl.DeltaToDiffReader;
 import org.openstreetmap.osmosis.apidb.v0_6.impl.SchemaVersionValidator;
 import org.openstreetmap.osmosis.core.container.v0_6.ChangeContainer;
+import org.openstreetmap.osmosis.core.database.DatabaseLocker;
 import org.openstreetmap.osmosis.core.database.DatabaseLoginCredentials;
 import org.openstreetmap.osmosis.core.database.DatabasePreferences;
 import org.openstreetmap.osmosis.core.lifecycle.ReleasableIterator;
@@ -109,13 +110,17 @@ public class ApidbChangeReader implements RunnableChangeSource {
      * Reads all data from the database and send it to the sink.
      */
     public void run() {
-        try (DatabaseContext2 dbCtx = new DatabaseContext2(loginCredentials)) {
+        try (DatabaseContext2 dbCtx = new DatabaseContext2(loginCredentials);
+				DatabaseLocker locker = new DatabaseLocker(dbCtx.getDataSource(), false)) {
         	dbCtx.executeWithinTransaction(new TransactionCallbackWithoutResult() {
 				@Override
 				protected void doInTransactionWithoutResult(TransactionStatus arg0) {
+					locker.lockDatabase(this.getClass().getSimpleName());
 					runImpl(dbCtx);
 				} });
 
-        }
+        } catch (final Exception e) {
+        	throw new RuntimeException(e);
+		}
     }
 }

--- a/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/v0_6/ApidbChangeWriter.java
+++ b/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/v0_6/ApidbChangeWriter.java
@@ -4,11 +4,13 @@ package org.openstreetmap.osmosis.apidb.v0_6;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.openstreetmap.osmosis.apidb.common.DatabaseContext2;
 import org.openstreetmap.osmosis.core.OsmosisRuntimeException;
 import org.openstreetmap.osmosis.apidb.v0_6.impl.ActionChangeWriter;
 import org.openstreetmap.osmosis.apidb.v0_6.impl.ChangeWriter;
 import org.openstreetmap.osmosis.apidb.v0_6.impl.SchemaVersionValidator;
 import org.openstreetmap.osmosis.core.container.v0_6.ChangeContainer;
+import org.openstreetmap.osmosis.core.database.DatabaseLocker;
 import org.openstreetmap.osmosis.core.database.DatabaseLoginCredentials;
 import org.openstreetmap.osmosis.core.database.DatabasePreferences;
 import org.openstreetmap.osmosis.core.task.common.ChangeAction;
@@ -27,6 +29,8 @@ public class ApidbChangeWriter implements ChangeSink {
     private final Map<ChangeAction, ActionChangeWriter> actionWriterMap;
 
     private final SchemaVersionValidator schemaVersionValidator;
+    private final DatabaseContext2 dbCtx;
+    private final DatabaseLocker locker;
 
     /**
      * Creates a new instance.
@@ -39,12 +43,14 @@ public class ApidbChangeWriter implements ChangeSink {
     public ApidbChangeWriter(DatabaseLoginCredentials loginCredentials, DatabasePreferences preferences,
             boolean populateCurrentTables) {
         changeWriter = new ChangeWriter(loginCredentials, populateCurrentTables);
-        actionWriterMap = new HashMap<ChangeAction, ActionChangeWriter>();
+        actionWriterMap = new HashMap<>();
         actionWriterMap.put(ChangeAction.Create, new ActionChangeWriter(changeWriter, ChangeAction.Create));
         actionWriterMap.put(ChangeAction.Modify, new ActionChangeWriter(changeWriter, ChangeAction.Modify));
         actionWriterMap.put(ChangeAction.Delete, new ActionChangeWriter(changeWriter, ChangeAction.Delete));
 
         schemaVersionValidator = new SchemaVersionValidator(loginCredentials, preferences);
+        dbCtx = new DatabaseContext2(loginCredentials);
+        locker = new DatabaseLocker(dbCtx.getDataSource(), true);
     }
 
     /**
@@ -59,6 +65,7 @@ public class ApidbChangeWriter implements ChangeSink {
      */
     public void process(ChangeContainer change) {
         ChangeAction action;
+        this.locker.lockDatabase(this.getClass().getSimpleName());
 
         // Verify that the schema version is supported.
         schemaVersionValidator.validateVersion(ApidbVersionConstants.SCHEMA_MIGRATIONS);
@@ -85,6 +92,8 @@ public class ApidbChangeWriter implements ChangeSink {
      * {@inheritDoc}
      */
     public void close() {
+        this.locker.unlockDatabase();
         changeWriter.close();
+        this.dbCtx.close();
     }
 }

--- a/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/v0_6/ApidbCurrentReader.java
+++ b/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/v0_6/ApidbCurrentReader.java
@@ -9,6 +9,7 @@ import org.openstreetmap.osmosis.apidb.v0_6.impl.AllEntityDao;
 import org.openstreetmap.osmosis.apidb.v0_6.impl.SchemaVersionValidator;
 import org.openstreetmap.osmosis.core.container.v0_6.BoundContainer;
 import org.openstreetmap.osmosis.core.container.v0_6.EntityContainer;
+import org.openstreetmap.osmosis.core.database.DatabaseLocker;
 import org.openstreetmap.osmosis.core.database.DatabaseLoginCredentials;
 import org.openstreetmap.osmosis.core.database.DatabasePreferences;
 import org.openstreetmap.osmosis.core.domain.v0_6.Bound;
@@ -90,13 +91,16 @@ public class ApidbCurrentReader implements RunnableSource {
      * Reads all data from the database and send it to the sink.
      */
     public void run() {
-        try (DatabaseContext2 dbCtx = new DatabaseContext2(loginCredentials)) {
+		try (DatabaseContext2 dbCtx = new DatabaseContext2(loginCredentials);
+				DatabaseLocker locker = new DatabaseLocker(dbCtx.getDataSource(), false)) {
         	dbCtx.executeWithinTransaction(new TransactionCallbackWithoutResult() {
-
 				@Override
 				protected void doInTransactionWithoutResult(TransactionStatus arg0) {
+					locker.lockDatabase(this.getClass().getSimpleName());
 					runImpl(dbCtx);
 				} });
-        }
+		} catch (final Exception e) {
+			throw new RuntimeException(e);
+		}
     }
 }

--- a/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/v0_6/ApidbFileReplicator.java
+++ b/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/v0_6/ApidbFileReplicator.java
@@ -10,6 +10,7 @@ import org.openstreetmap.osmosis.apidb.v0_6.impl.SystemTimeLoader;
 import org.openstreetmap.osmosis.apidb.v0_6.impl.TimeDao;
 import org.openstreetmap.osmosis.apidb.v0_6.impl.TransactionDao;
 import org.openstreetmap.osmosis.apidb.v0_6.impl.TransactionManager;
+import org.openstreetmap.osmosis.core.database.DatabaseLocker;
 import org.openstreetmap.osmosis.core.database.DatabaseLoginCredentials;
 import org.openstreetmap.osmosis.core.database.DatabasePreferences;
 import org.openstreetmap.osmosis.core.task.v0_6.ChangeSink;
@@ -95,8 +96,12 @@ public class ApidbFileReplicator implements RunnableChangeSource {
 	 */
 	@Override
 	public void run() {
-        try (DatabaseContext2 dbCtx = new DatabaseContext2(loginCredentials)) {
+		try (DatabaseContext2 dbCtx = new DatabaseContext2(loginCredentials);
+				DatabaseLocker locker = new DatabaseLocker(dbCtx.getDataSource(), false)) {
+			locker.lockDatabase(this.getClass().getSimpleName());
         	runImpl(dbCtx);
-        }
+		} catch (final Exception e) {
+			throw new RuntimeException(e);
+		}
 	}
 }

--- a/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/v0_6/ApidbReader.java
+++ b/osmosis-apidb/src/main/java/org/openstreetmap/osmosis/apidb/v0_6/ApidbReader.java
@@ -11,6 +11,7 @@ import org.openstreetmap.osmosis.apidb.v0_6.impl.EntitySnapshotReader;
 import org.openstreetmap.osmosis.apidb.v0_6.impl.SchemaVersionValidator;
 import org.openstreetmap.osmosis.core.container.v0_6.BoundContainer;
 import org.openstreetmap.osmosis.core.container.v0_6.EntityContainer;
+import org.openstreetmap.osmosis.core.database.DatabaseLocker;
 import org.openstreetmap.osmosis.core.database.DatabaseLoginCredentials;
 import org.openstreetmap.osmosis.core.database.DatabasePreferences;
 import org.openstreetmap.osmosis.core.domain.v0_6.Bound;
@@ -95,13 +96,17 @@ public class ApidbReader implements RunnableSource {
      * Reads all data from the database and send it to the sink.
      */
     public void run() {
-        try (DatabaseContext2 dbCtx = new DatabaseContext2(loginCredentials)) {
+		try (DatabaseContext2 dbCtx = new DatabaseContext2(loginCredentials);
+				DatabaseLocker locker = new DatabaseLocker(dbCtx.getDataSource(), false)) {
         	dbCtx.executeWithinTransaction(new TransactionCallbackWithoutResult() {
 				@Override
 				protected void doInTransactionWithoutResult(TransactionStatus arg0) {
+					locker.lockDatabase(this.getClass().getSimpleName());
 					runImpl(dbCtx);
 				}
         	});
-        }
+		} catch (final Exception e) {
+			throw new RuntimeException(e);
+		}
     }
 }

--- a/osmosis-core/build.gradle
+++ b/osmosis-core/build.gradle
@@ -8,6 +8,8 @@ dependencies {
     compile group: 'com.fasterxml.woodstox', name: 'woodstox-core', version: dependencyVersionWoodstoxCore
     compile group: 'org.codehaus.woodstox', name: 'stax2-api', version: dependencyVersionWoodstoxStax2
     compile group: 'org.apache.commons', name: 'commons-compress', version: dependencyVersionCommonsCompress
+    compile group: 'xerces', name: 'xercesImpl', version: dependencyVersionXerces
+    compile group: 'org.springframework', name: 'spring-jdbc', version: dependencyVersionSpring
 }
 
 /*

--- a/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/database/DatabaseLocker.java
+++ b/osmosis-core/src/main/java/org/openstreetmap/osmosis/core/database/DatabaseLocker.java
@@ -1,0 +1,142 @@
+// This software is released into the Public Domain.  See copying.txt for details.
+package org.openstreetmap.osmosis.core.database;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.logging.Logger;
+
+import javax.sql.DataSource;
+
+/**
+ * A check against the database to see if it is locked.
+ *
+ * @author mcuthbert
+ */
+public class DatabaseLocker implements AutoCloseable {
+
+    private static Logger logger = Logger.getLogger(DatabaseLocker.class.getSimpleName());
+    private final DataSource source;
+    private final boolean writeLock;
+    private boolean enabled = true;
+    private int lockedIdentifier = -1;
+
+    /**
+     * Static function to fully unlock the database.
+     *
+     * @param source {@link DataSource} to execute the query
+     */
+    public static void fullUnlockDatabase(final DataSource source) {
+        unlockDatabase(-1, source);
+    }
+
+    private static void unlockDatabase(final int identifier, final DataSource source) {
+        try (Connection connection = source.getConnection();
+                PreparedStatement statement = connection.prepareStatement("SELECT unlock_database(?)")) {
+            statement.setInt(1, identifier);
+            final ResultSet result = statement.executeQuery();
+            if (result.next()) {
+                final boolean unlocked = result.getBoolean(1);
+                if (unlocked) {
+                    logger.info(String.format("Unlocked database using identifier %d.", identifier));
+                    return;
+                }
+            }
+            throw new RuntimeException("Failed to unlock the database");
+        } catch (final SQLException e) {
+            throw new RuntimeException("Failed to unlock the database", e);
+        }
+    }
+
+    /**
+     * Default Constructor.
+     *
+     * @param source The DataSource for the connection
+     * @param writeLock Whether the lock that is being requested is a write lock
+     */
+    public DatabaseLocker(final DataSource source, final boolean writeLock) {
+        this.source = source;
+        this.writeLock = writeLock;
+        // check to see if the function exists in the database and if it doesn't then throw a
+        // warning on the log and don't try any locking
+        try (Connection connection = source.getConnection();
+                Statement statement = connection.createStatement()) {
+            statement.executeQuery("SELECT 'lock_database'::regproc, 'unlock_database'::regproc");
+        } catch (final Exception e) {
+            logger.warning("Locking functions do not exist in database. Disabling locking.");
+            this.enabled = false;
+        }
+    }
+
+    /**
+     * Helper function for primary lock database function that simply sets the source to empty string.
+     *
+     * @param process The process that is locking the database
+     */
+    public void lockDatabase(final String process) {
+        this.lockDatabase(process, "");
+    }
+
+    /**
+     * Will attempt to lock the database.
+     *
+     * @param process
+     *          The process that will lock the database. This would be something like "Extracts" or "Replication".
+     * @param description
+     *          The source of the process. This is basically a description for the process, like
+     *          "Pipeline Extraction for Build X".
+     */
+    public void lockDatabase(final String process, final String description) {
+        if (this.enabled) {
+            String lockName = "read";
+            if (this.writeLock) {
+                lockName = "write";
+            }
+            try (Connection connection = source.getConnection();
+                    PreparedStatement statement = connection.prepareStatement("SELECT lock_database(?, ?, ?, ?)")) {
+                statement.setString(1, process);
+                statement.setString(2, description);
+                statement.setString(3, InetAddress.getLocalHost().getHostName());
+                statement.setBoolean(4, this.writeLock);
+                final ResultSet result = statement.executeQuery();
+                if (result.next()) {
+                    this.lockedIdentifier = result.getInt(1);
+                    logger.info(String.format("Obtained %s lock to database for process: %s "
+                                    + "from source: '%s', with lockedID: %d",
+                            lockName, process, description, this.lockedIdentifier));
+                } else {
+                    throw new RuntimeException("Failed to retrieve lock for the database.");
+                }
+            } catch (final SQLException | UnknownHostException e) {
+                throw new RuntimeException("Failed to lock the database.", e);
+            }
+        }
+    }
+
+    /**
+     * Will attempt to unlock the database with the given locked identifier.
+     */
+    public void unlockDatabase() {
+        if (this.enabled && this.lockedIdentifier > 0) {
+            unlockDatabase(this.lockedIdentifier, this.source);
+        }
+    }
+
+    /**
+     * Does a full unlock of the database. So no matter what is locking it, this will unlock it.
+     */
+    public void fullUnlockDatabase() {
+        if (this.enabled) {
+            fullUnlockDatabase(this.source);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        this.unlockDatabase();
+    }
+}

--- a/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/common/DatabaseContext.java
+++ b/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/common/DatabaseContext.java
@@ -66,6 +66,14 @@ public class DatabaseContext implements AutoCloseable {
         }
     }
 
+	/**
+	 * Returns the DataSource associated with this database context.
+	 *
+	 * @return {@link DataSource}
+	 */
+	public DataSource getDataSource() {
+		return this.dataSource;
+	}
 
 	/**
 	 * Begins a new database transaction. This is not required if

--- a/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/PostgreSqlTruncator.java
+++ b/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/PostgreSqlTruncator.java
@@ -3,6 +3,7 @@ package org.openstreetmap.osmosis.pgsnapshot.v0_6;
 
 import java.util.logging.Logger;
 
+import org.openstreetmap.osmosis.core.database.DatabaseLocker;
 import org.openstreetmap.osmosis.core.database.DatabaseLoginCredentials;
 import org.openstreetmap.osmosis.core.database.DatabasePreferences;
 import org.openstreetmap.osmosis.core.task.common.RunnableTask;
@@ -20,7 +21,6 @@ public class PostgreSqlTruncator implements RunnableTask {
 	
 	private static final Logger LOG = Logger.getLogger(PostgreSqlTruncator.class.getName());
 	
-	
 	// These tables will be truncated.
 	private static final String[] SQL_TABLE_NAMES = {
 		"actions",
@@ -30,10 +30,9 @@ public class PostgreSqlTruncator implements RunnableTask {
 		"relations", "relation_tags", "relation_members"
 	};
 	
-	
 	private DatabaseContext dbCtx;
 	private SchemaVersionValidator schemaVersionValidator;
-	
+	private DatabaseLocker locker;
 	
 	/**
 	 * Creates a new instance.
@@ -45,10 +44,9 @@ public class PostgreSqlTruncator implements RunnableTask {
 	 */
 	public PostgreSqlTruncator(DatabaseLoginCredentials loginCredentials, DatabasePreferences preferences) {
 		dbCtx = new DatabaseContext(loginCredentials);
-		
+		this.locker = new DatabaseLocker(new DatabaseContext(loginCredentials).getDataSource(), true);
 		schemaVersionValidator = new SchemaVersionValidator(dbCtx.getJdbcTemplate(), preferences);
 	}
-	
 	
 	/**
 	 * Truncates all data from the database.
@@ -58,7 +56,7 @@ public class PostgreSqlTruncator implements RunnableTask {
 			schemaVersionValidator.validateVersion(PostgreSqlVersionConstants.SCHEMA_VERSION);
 			
 			dbCtx.beginTransaction();
-			
+			this.locker.lockDatabase(this.getClass().getSimpleName());
 			LOG.fine("Truncating tables.");
 			for (int i = 0; i < SQL_TABLE_NAMES.length; i++) {
 				if (dbCtx.doesTableExist(SQL_TABLE_NAMES[i])) {
@@ -77,6 +75,7 @@ public class PostgreSqlTruncator implements RunnableTask {
 			LOG.fine("Complete.");
 			
 		} finally {
+			this.locker.unlockDatabase();
 			dbCtx.close();
 		}
 	}

--- a/osmosis-pgsnapshot/src/test/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/impl/DatabaseLockerTest.java
+++ b/osmosis-pgsnapshot/src/test/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/impl/DatabaseLockerTest.java
@@ -1,0 +1,145 @@
+// This software is released into the Public Domain.  See copying.txt for details.
+package org.openstreetmap.osmosis.pgsnapshot.v0_6.impl;
+
+import static org.junit.Assert.fail;
+
+import javax.sql.DataSource;
+
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import org.openstreetmap.osmosis.core.database.DatabaseLocker;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+/**
+ * Tests the basic functionality around the {@link DatabaseLocker}.
+ *
+ * @author mcuthbert
+ */
+@FixMethodOrder(MethodSorters.JVM)
+public class DatabaseLockerTest {
+
+    /**
+     * Simple test to make sure that we can obtain a write lock and then release it.
+     */
+    @Test
+    public void writeLockTest() {
+        try (DatabaseLocker locker = new DatabaseLocker(this.dataSource(), true)) {
+            locker.lockDatabase("WriteLock", "WRITE_TEST_LOCK");
+        } catch (final Exception e) {
+            fail("Write lock should not have thrown an exception");
+        }
+    }
+
+    /**
+     * Simple test to make sure that we can obtain a read lock and then release it.
+     */
+    @Test
+    public void readLockTest() {
+        try (DatabaseLocker locker = new DatabaseLocker(this.dataSource(), false)) {
+            locker.lockDatabase("ReadLock", "READ_LOCK_TEST");
+        } catch (final Exception e) {
+            fail("Read lock should not have thrown an exception");
+        }
+    }
+
+    /**
+     * Test to show that if we try to obtain a write lock when there is a read lock that we will
+     * get an exception.
+     *
+     * @throws Exception if the datasource cannot be established
+     */
+    @Test
+    public void writeWithReadLockTest() throws Exception {
+        final DatabaseLocker writeLocker = new DatabaseLocker(this.dataSource(), true);
+        final DatabaseLocker readLocker = new DatabaseLocker(this.dataSource(), false);
+        readLocker.lockDatabase("ReadLock", "WRITE_WITH_READ_LOCK_TEST_1");
+        try {
+            writeLocker.lockDatabase("WriteLock", "WRITE_WITH_READ_LOCK_TEST_2");
+            fail("Write lock should have thrown an exception");
+        } catch (final Exception e) {
+            // we should expect an exception to be thrown
+        }
+        readLocker.unlockDatabase();
+        writeLocker.lockDatabase("WriteLock", "WRITE_WITH_READ_LOCK_TEST_3");
+        writeLocker.unlockDatabase();
+    }
+
+    /**
+     * Test to show that if we try to obtain a write lock when there is already a write lock that we
+     * will get an exception.
+     *
+     * @throws Exception if the datasource cannot be established
+     */
+    @Test
+    public void writeWithWriteLockTest() throws Exception {
+        final DatabaseLocker writeLocker1 = new DatabaseLocker(this.dataSource(), true);
+        final DatabaseLocker writeLocker2 = new DatabaseLocker(this.dataSource(), true);
+        writeLocker1.lockDatabase("WriteLock1", "WRITE_WITH_WRITE_LOCK_TEST_1");
+        try {
+            writeLocker2.lockDatabase("WriteLock2", "WRITE_WITH_WRITE_LOCK_TEST_2");
+            fail("Write lock should have thrown an exception");
+        } catch (final Exception e) {
+            // we should expect an exception to be thrown
+        }
+        writeLocker1.unlockDatabase();
+        writeLocker2.lockDatabase("WriteLock2", "WRITE_WITH_WRITE_LOCK_TEST_3");
+        writeLocker2.unlockDatabase();
+    }
+
+    /**
+     * Test to show that we can obtain multiple read locks.
+     *
+     * @throws Exception if the datasource cannot be established
+     */
+    @Test
+    public void readWithReadLockTest() throws Exception {
+        final DatabaseLocker[] lockers = new DatabaseLocker[10];
+        try {
+            for (int i = 0; i < 10; i++) {
+                lockers[i] = new DatabaseLocker(this.dataSource(), false);
+                lockers[i].lockDatabase("ReadLock" + i, "READ_WITH_READ_LOCK_TEST_" + i);
+            }
+        } finally {
+            // unlock all the databases
+            for (int i = 0; i < 10; i++) {
+                if (lockers[i] != null) {
+                    lockers[i].unlockDatabase();
+                }
+            }
+        }
+    }
+
+    /**
+     * Test to show that if we try to obtain a read lock when there is already a write lock that we
+     * will get an exception.
+     *
+     * @throws Exception if the datasource cannot be established
+     */
+    @Test
+    public void readWithWriteLockTest() throws Exception {
+        final DatabaseLocker readLocker = new DatabaseLocker(this.dataSource(), false);
+        final DatabaseLocker writeLocker = new DatabaseLocker(this.dataSource(), true);
+        writeLocker.lockDatabase("WriteLock", "READ_WITH_WRITE_LOCK_TEST_1");
+        try {
+            readLocker.lockDatabase("ReadLock", "READ_WITH_WRITE_LOCK_TEST_2");
+            fail("Read lock should have thrown an exception");
+        } catch (final Exception e) {
+            // we should expect an exception to be thrown
+        }
+        writeLocker.unlockDatabase();
+        readLocker.lockDatabase("ReadLock", "READ_WITH_WRITE_LOCK_TEST_3");
+        readLocker.unlockDatabase();
+    }
+
+    private DataSource dataSource() throws Exception {
+        Class.forName("org.postgresql.Driver");
+        final DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName("org.postgresql.Driver");
+        dataSource.setUrl("jdbc:postgresql://db:5432/pgosmsnap06_test");
+        dataSource.setUsername("osm");
+        dataSource.setPassword("password");
+        dataSource.setSchema("public");
+        return dataSource;
+    }
+}

--- a/package/script/pgsnapshot_schema_0.6_changes.sql
+++ b/package/script/pgsnapshot_schema_0.6_changes.sql
@@ -31,3 +31,65 @@ CREATE TABLE replication_changes (
   query text NOT NULL,
   arguments text
 );
+
+DROP TABLE IF EXISTS state;
+
+ CREATE TABLE state (
+  id SERIAL,
+  tstamp TIMESTAMP without time zone NOT NULL DEFAULT(NOW()),
+  sequence_number BIGINT NOT NULL,
+  state_timestamp TIMESTAMP WITHOUT time zone NOT NULL,
+  disabled BOOLEAN NOT NULL DEFAULT(false)
+);
+
+ DROP TABLE IF EXISTS locked;
+
+ CREATE TABLE locked (
+  id SERIAL,
+  started TIMESTAMP WITHOUT time zone NOT NULL DEFAULT(NOW()),
+  process TEXT NOT NULL,
+  source TEXT NOT NULL,
+  location TEXT NOT NULL,
+  write_lock BOOLEAN NOT NULL DEFAULT(false)
+);
+
+ DROP FUNCTION IF EXIST lock_database(TEXT, TEXT, TEXT);
+CREATE OR REPLACE FUNCTION lock_database(new_process TEXT, new_source TEXT, new_location TEXT, request_write_lock BOOLEAN) RETURNS INT AS $$
+  DECLARE locked_id INT;
+  DECLARE current_id INT;
+  DECLARE current_process TEXT;
+  DECLARE current_source TEXT;
+  DECLARE current_location TEXT;
+  DECLARE current_write_lock BOOLEAN;
+BEGIN
+
+   SELECT id, process, source, location, write_lock
+    INTO current_id, current_process, current_source, current_location, current_write_lock
+    FROM locked ORDER BY write_lock DESC NULLS LAST LIMIT 1;
+  IF (current_process IS NULL OR CHAR_LENGTH(current_process) = 0 OR (request_write_lock = FALSE AND current_write_lock = FALSE)) THEN
+    INSERT INTO locked (process, source, location, write_lock) VALUES (new_process, new_source, new_location, request_write_lock) RETURNING id INTO locked_id;
+    RETURN locked_id;
+  ELSE
+    RAISE EXCEPTION 'Database is locked by another id {%}, process {%}, source {%}, location {%}', current_id, current_process, current_source, current_location;
+  END IF;
+END;
+$$ LANGUAGE plpgsql VOLATILE;
+
+ CREATE OR REPLACE FUNCTION unlock_database(locked_id INT) RETURNS BOOLEAN AS $$
+  DECLARE response BOOLEAN;
+  DECLARE exist_count INT;
+BEGIN
+  IF (locked_id = -1) THEN
+    DELETE FROM locked;
+    RETURN true;
+  ELSE
+    SELECT COUNT(*) INTO exist_count FROM locked WHERE id = locked_id;
+    IF (exist_count = 1) THEN
+      DELETE FROM locked WHERE id = locked_id;
+      RETURN true;
+    ELSE
+      RETURN false;
+    END IF;
+  END IF;
+END;
+$$ LANGUAGE plpgsql VOLATILE;


### PR DESCRIPTION
This PR adds database locking functionality for Osmosis. The locking is quite simplistic allowing read and write locks on a first come first serve basis. Multiple read locks can be obtained and only a single write lock may be obtained. This allows the any incoming read requests from external processes on your database to wait until some write operation has completed before executing the read. It does assume any external read operations will use the locking functionality as it doesn't use database level locking. This does give a little more flexibility in how you use it. If the database that you are replicating data into does not have the required locking functions it will work exactly as it did before, as if there is no locking.