### PR TITLE
Replace Travis CI with GitHub Actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,10 @@
+name: Continuous Integration
+on: [push]
+jobs:
+  Continous-Integration:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build
+        run: ./docker.sh ./gradlew build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-services:
-  - docker
-
-script:
-  - ./docker.sh ./gradlew build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Osmosis
-[![Build Status](https://travis-ci.org/openstreetmap/osmosis.svg?branch=master)](https://travis-ci.org/openstreetmap/osmosis)
+![Build Status](https://github.com/openstreetmap/osmosis/actions/workflows/continous-integration.yml/badge.svg)
 
 ## Overview
 


### PR DESCRIPTION
GitHub Actions didn't exist when Travis CI was set up. Travis CI seems to be broken now that travis-ci.org is no longer performing builds.  We could possibly cut over to travis-ci.com but it seems like a good opportunity to switch over to GitHub Actions.  It's a fairly simple build script because most of the build is performed via `docker.sh` and `Gradle`.