### PR TITLE
Don't compress OSMHeader file blocks

### DIFF
--- a/osmosis-osm-binary/src/main/java/org/openstreetmap/osmosis/osmbinary/file/BlockOutputStream.java
+++ b/osmosis-osm-binary/src/main/java/org/openstreetmap/osmosis/osmbinary/file/BlockOutputStream.java
@@ -23,10 +23,6 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-enum CompressFlags {
-    NONE, DEFLATE
-}
-
 public class BlockOutputStream {
 
     public BlockOutputStream(OutputStream output) {

--- a/osmosis-osm-binary/src/main/java/org/openstreetmap/osmosis/osmbinary/file/CompressFlags.java
+++ b/osmosis-osm-binary/src/main/java/org/openstreetmap/osmosis/osmbinary/file/CompressFlags.java
@@ -1,0 +1,5 @@
+package org.openstreetmap.osmosis.osmbinary.file;
+
+public enum CompressFlags {
+    NONE, DEFLATE
+}

--- a/osmosis-pbf/src/main/java/crosby/binary/osmosis/OsmosisSerializer.java
+++ b/osmosis-pbf/src/main/java/crosby/binary/osmosis/OsmosisSerializer.java
@@ -35,6 +35,7 @@ import org.openstreetmap.osmosis.osmbinary.Osmformat.DenseInfo;
 import org.openstreetmap.osmosis.osmbinary.StringTable;
 import org.openstreetmap.osmosis.osmbinary.Osmformat.Relation.MemberType;
 import org.openstreetmap.osmosis.osmbinary.file.BlockOutputStream;
+import org.openstreetmap.osmosis.osmbinary.file.CompressFlags;
 import org.openstreetmap.osmosis.osmbinary.file.FileBlock;
 
 /**
@@ -461,8 +462,7 @@ public class OsmosisSerializer extends BinarySerializer implements Sink {
       }
       Osmformat.HeaderBlock message = headerblock.build();
       try {
-          output.write(FileBlock.newInstance("OSMHeader", message
-                  .toByteString(), null));
+          output.write(FileBlock.newInstance("OSMHeader", message.toByteString(), null), CompressFlags.NONE);
       } catch (IOException e) {
           throw new OsmosisRuntimeException("Unable to write OSM header.", e);
       }


### PR DESCRIPTION
Who hasn't seen the annoying "Compressed buffers are too short, causing extra copy" message when writing PBF files with osmosis/osm-binary, well sometime yesterday evening I had enough :-)

The root cause of the message is that the contents of an OSMHeader file block seem to be typically ~80 bytes which when deflated inflates to about 90 (if this assumption is mistaken please shout out). 

This PR implements the simplest possible fix by not trying to deflate OSMHeader file blocks. This will need some compatibility testing as other implementations compress the data too and consumers may be simply assuming that they need to decompress the contents.

I intend to, if this is merged, make the same PR against osm-binary. 