### PR TITLE
Update issues link to reference GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ See [Development](./doc/development.md) for details.
 
 ## Issue Tracking
 
-See https://trac.openstreetmap.org/query?status=!closed&component=osmosis
+See https://github.com/openstreetmap/osmosis/issues


### PR DESCRIPTION
The README was pointing to the old OSM Trac server which has been
decommissioned.  This change updates the link to point to the Osmosis
GitHub issues.