### PR TITLE
Enable CI for pull requests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,5 +1,5 @@
 name: Continuous Integration
-on: [push]
+on: [push, pull_request]
 jobs:
   Continous-Integration:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The existing build is only triggering on push events.  Adding the
pull_request event will (hopefully) ensure that builds are triggered for
pull requests and their status shown on pull requests.