### PR TITLE
On enableKeepPartialLinestring, output a closed linestring if the original way is closed even on missing start/end node #133

### DIFF
--- a/doc/detailed-usage.adoc
+++ b/doc/detailed-usage.adoc
@@ -1684,7 +1684,9 @@ the linestring geometry column. |yes, no |no
 built from option enableLinestringBuilder. When an invalid or a missing
 node location is encountered the linestring is not built by default.
 Enabling this option keeps it as a partial linestring. It will result in
-a different geometry than the original one. |yes, no |no
+a different geometry than the original one. If the original geometry is
+a loop the imported geometry is a loop, even in case of faulty start and
+end. |yes, no |no
 
 |nodeLocationStoreType |This option only takes effect if at least one of
 the enableBboxBuilder and enableLinestringBuilder options are enabled.
@@ -1902,7 +1904,8 @@ is more efficient for smaller datasets. |"InMemory", "TempFile",
 built. When an invalid or a missing node location is encountered the
 linestring is not built by default. Enabling this option keeps it as a
 partial linestring. It will result in a different geometry than the
-original one. |yes, no |no
+original one. If the original geometry is a loop the imported geometry
+is a loop, even in case of faulty start and end. |yes, no |no
 |=======================================================================
 
 ==== --write-pgsimp-dump (--wsd)
@@ -1939,7 +1942,9 @@ the linestring geometry column. |yes, no |no
 built from option enableLinestringBuilder. When an invalid or a missing
 node location is encountered the linestring is not built by default.
 Enabling this option keeps it as a partial linestring. It will result in
-a different geometry than the original one. |yes, no |no
+a different geometry than the original one. If the original geometry is
+a loop the imported geometry is a loop, even in case of faulty start and
+end. |yes, no |no
 
 |nodeLocationStoreType |This option only takes effect if at least one of
 the enableBboxBuilder and enableLinestringBuilder options are enabled.
@@ -1957,7 +1962,8 @@ the default database geometry building implementation, or the
 built. When an invalid or a missing node location is encountered the
 linestring is not built by default. Enabling this option keeps it as a
 partial linestring. It will result in a different geometry than the
-original one. |yes, no |no
+original one. If the original geometry is a loop the imported geometry
+is a loop, even in case of faulty start and end. |yes, no |no
 |=======================================================================
 
 ==== --truncate-pgsimp (--ts)

--- a/osmosis-pgsimple/src/main/java/org/openstreetmap/osmosis/pgsimple/v0_6/impl/WayGeometryBuilder.java
+++ b/osmosis-pgsimple/src/main/java/org/openstreetmap/osmosis/pgsimple/v0_6/impl/WayGeometryBuilder.java
@@ -216,6 +216,11 @@ public class WayGeometryBuilder implements Closeable {
 			}
 		}
 	
+		if (enableKeepPartialLinestring && way.isClosed() && linePoints.size() > 1
+			&& !linePoints.get(0).equals(linePoints.get(linePoints.size() - 1))) {
+			linePoints.add(linePoints.get(0));
+		}
+		
 		if (numValidNodes >= 2) {	
 			return createLinestring(linePoints);
 		} else {

--- a/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/impl/WayGeometryBuilder.java
+++ b/osmosis-pgsnapshot/src/main/java/org/openstreetmap/osmosis/pgsnapshot/v0_6/impl/WayGeometryBuilder.java
@@ -213,6 +213,12 @@ public class WayGeometryBuilder implements Closeable {
 				}
 			}
 		}
+		
+		if (enableKeepPartialLinestring && way.isClosed() && linePoints.size() > 1
+			&& !linePoints.get(0).equals(linePoints.get(linePoints.size() - 1))) {
+			linePoints.add(linePoints.get(0));
+		}
+		
 		return createLinestring(linePoints);
 	}
 	


### PR DESCRIPTION
When using `enableKeepPartialLinestring` option, the output linestring should keep the closed property of the geometry, even when the location of the start/end point is missing.

Implement #133

cc @Famlam